### PR TITLE
Cant write Unicode chars fix

### DIFF
--- a/src/War3Net.Common/Extensions/BinaryWriterExtensions.cs
+++ b/src/War3Net.Common/Extensions/BinaryWriterExtensions.cs
@@ -13,17 +13,17 @@ namespace War3Net.Common.Extensions
     {
         public static void WriteString(this BinaryWriter writer, string s)
         {
-            var endsWithNullChar = false;
+            string toBeWritten = string.Empty;
             foreach (var c in s ?? string.Empty)
             {
-                writer.Write(c);
-                endsWithNullChar = c == char.MinValue;
+                if(c == char.MinValue){
+                    toBeWritten+=char.MinValue;
+                    break;
+                }
+                toBeWritten+=c;
             }
 
-            if (!endsWithNullChar)
-            {
-                writer.Write(char.MinValue);
-            }
+            writer.Write(toBeWritten);
         }
     }
 }


### PR DESCRIPTION
Otherwise attempting to write string containing "\uD83D\uDCAB" is not possible.
Unicode surrogate characters must be written out as pairs together in the same call, not individually.
https://docs.microsoft.com/en-us/dotnet/api/system.io.binarywriter.write?view=netcore-3.1#System_IO_BinaryWriter_Write_System_Char___System_Int32_System_Int32_