### PR TITLE
ValueAsBool and ValueAsChar can convert ints and strings respectively

### DIFF
--- a/src/War3Net.Build.Core/Object/ObjectDataModification.cs
+++ b/src/War3Net.Build.Core/Object/ObjectDataModification.cs
@@ -39,8 +39,13 @@ namespace War3Net.Build.Object
             {
                 if (Value is int i)
                 {
-                    if (i == 1) return true;
-                    else if (i == 0) return false;
+                    switch (i)
+                    {
+                        case 1:
+                            return true;
+                        case 0:
+                            return false;
+                    }
                 }
 
                 throw new InvalidOperationException();

--- a/src/War3Net.Build.Core/Object/ObjectDataModification.cs
+++ b/src/War3Net.Build.Core/Object/ObjectDataModification.cs
@@ -33,7 +33,19 @@ namespace War3Net.Build.Object
 
         public string ValueAsString => Value is string s ? s : throw new InvalidOperationException();
 
-        public bool ValueAsBool => Value is bool b ? b : throw new InvalidOperationException();
+        public bool ValueAsBool
+        {
+            get
+            {
+                if (Value is int i)
+                {
+                    if (i == 1) return true;
+                    else if (i == 0) return false;
+                }
+
+                throw new InvalidOperationException();
+            }
+        }
 
         public char ValueAsChar => Value is char c ? c : throw new InvalidOperationException();
 

--- a/src/War3Net.Build.Core/Object/ObjectDataModification.cs
+++ b/src/War3Net.Build.Core/Object/ObjectDataModification.cs
@@ -37,6 +37,11 @@ namespace War3Net.Build.Object
         {
             get
             {
+                if (Value is bool b)
+                {
+                    return b;
+                }
+
                 if (Value is int i)
                 {
                     switch (i)

--- a/src/War3Net.Build.Core/Object/ObjectDataModification.cs
+++ b/src/War3Net.Build.Core/Object/ObjectDataModification.cs
@@ -47,7 +47,7 @@ namespace War3Net.Build.Object
             }
         }
 
-        public char ValueAsChar => Value is char c ? c : throw new InvalidOperationException();
+        public char ValueAsChar => Value is char c ? c : Value is string str && str.Length == 1 ? char.Parse(str) : throw new InvalidOperationException();
 
         protected object ReadValue(BinaryReader reader, ObjectDataFormatVersion formatVersion)
         {

--- a/tests/War3Net.Build.Core.Tests/Object/ObjectDataModificationTests.cs
+++ b/tests/War3Net.Build.Core.Tests/Object/ObjectDataModificationTests.cs
@@ -12,20 +12,16 @@ namespace War3Net.Build.Core.Tests.Object
     [TestClass]
     public class ObjectDataModificationTests
     {
-        [TestMethod]
-        public void ObjectDataModification_ValueAsBool_True()
+        [DataTestMethod]
+        [DataRow(true, true)]
+        [DataRow(true, 1)]
+        [DataRow(false, false)]
+        [DataRow(false, 0)]
+        public void ObjectDataModification_ValueAsBool_Correct(bool expected, object value)
         {
             var mod = new ObjectDataModificationMock();
-            mod.Value = 1;
-            Assert.AreEqual(true, mod.ValueAsBool);
-        }
-
-        [TestMethod]
-        public void ObjectDataModification_ValueAsBool_False()
-        {
-            var mod = new ObjectDataModificationMock();
-            mod.Value = 0;
-            Assert.AreEqual(false, mod.ValueAsBool);
+            mod.Value = value;
+            Assert.AreEqual(expected, mod.ValueAsBool);
         }
 
         [DataTestMethod]

--- a/tests/War3Net.Build.Core.Tests/Object/ObjectDataModificationTests.cs
+++ b/tests/War3Net.Build.Core.Tests/Object/ObjectDataModificationTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using War3Net.Build.Object;
+
+namespace War3Net.Build.Core.Tests.Object
+{
+    public class ObjectDataModificationMock : ObjectDataModification
+    {
+
+    }
+
+    [TestClass]
+    public class ObjectDataModificationTests
+    {
+        [TestMethod]
+        public void ObjectDataModification_ValueAsBool_True()
+        {
+            var mod = new ObjectDataModificationMock();
+            mod.Value = 1;
+            Assert.AreEqual(true, mod.ValueAsBool);
+        }
+
+        [TestMethod]
+        public void ObjectDataModification_ValueAsBool_False()
+        {
+            var mod = new ObjectDataModificationMock();
+            mod.Value = 0;
+            Assert.AreEqual(false, mod.ValueAsBool);
+        }
+
+        [DataTestMethod]
+        [DataRow("test")]
+        [DataRow(2)]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void ObjectDataModification_ValueAsBool_InvalidOperation(object value)
+        {
+            var mod = new ObjectDataModificationMock();
+            mod.Value = value;
+            _ = mod.ValueAsBool;
+        }
+    }
+}

--- a/tests/War3Net.Build.Core.Tests/Object/ObjectDataModificationTests.cs
+++ b/tests/War3Net.Build.Core.Tests/Object/ObjectDataModificationTests.cs
@@ -38,5 +38,28 @@ namespace War3Net.Build.Core.Tests.Object
             mod.Value = value;
             _ = mod.ValueAsBool;
         }
+
+        [DataTestMethod]
+        [DataRow('c', 'c')]
+        [DataRow('c', "c")]
+        [DataRow('C', "C")]
+        public void ObjectDataModification_ValueAsChar_Correct(char expected, object value)
+        {
+            var mod = new ObjectDataModificationMock();
+            mod.Value = value;
+            Assert.AreEqual(expected, mod.ValueAsChar);
+        }
+
+        [DataTestMethod]
+        [DataRow("test")]
+        [DataRow(2)]
+        [DataRow(2.0)]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void ObjectDataModification_ValueAsChar_InvalidOperation(object value)
+        {
+            var mod = new ObjectDataModificationMock();
+            mod.Value = value;
+            _ = mod.ValueAsChar;
+        }
     }
 }


### PR DESCRIPTION
Currently, ObjectDataModification.ValueAsBool and .ValueAsChar consistently throw exceptions when I read my object data values. I assume this is because they can't cast from things like 1, 0, "c", etc. I've made an attempt here to fix that. I might be misunderstanding where the issue lies however.