### PR TITLE
Add missing changelog entries

### DIFF
--- a/docs/changelogs/War3Net.Build.Core.changelog.md
+++ b/docs/changelogs/War3Net.Build.Core.changelog.md
@@ -4,23 +4,23 @@ All notable changes to the `War3Net.Build.Core` package, newest version first.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v6.0.3
+## v6.0.3 - 2026-07-04
 
 ### Changed
 
 - Updated `War3Net.IO.Mpq` from v6.0.2 to v6.0.3.
 
-## v6.0.2
+## v6.0.2 - 2026-03-01
 
 ### Breaking Changes
 
 - Updated target framework from .NET 5.0 to .NET 6.0.
 
-## v6.0.1
+## v6.0.1 - 2026-02-01
 
 _No functional changes; package readme and metadata updated for nuget.org presentation._
 
-## v6.0.0
+## v6.0.0 - 2026-01-25
 
 ### Breaking Changes
 
@@ -34,19 +34,19 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Fixed exception when deserializing `MapInfo.EditorVersion` as JSON string.
 
-## v1.5.3
+## v1.5.3 - 2020-10-29
 
 ### Added
 
 - Add `UseNewFormat` property to `MapCustomTextTriggers`.
 
-## v1.5.2
+## v1.5.2 - 2020-10-29
 
 ### Added
 
 - Support parsing and serializing `.wct` files.
 
-## v1.5.1
+## v1.5.1 - 2020-10-28
 
 ### Added
 
@@ -56,7 +56,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Fix `MapTriggers` serializer for old format could serialize `TriggerItemType.RootCategory` items.
 
-## v1.5.0
+## v1.5.0 - 2020-10-27
 
 ### Added
 
@@ -68,7 +68,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Update target framework from .NET Standard to .NET Core.
 
-## v1.4.0
+## v1.4.0 - 2020-09-14
 
 ### Breaking Changes
 
@@ -106,7 +106,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Fix string interpolation uses incorrect format string.
 
-## v1.3.7
+## v1.3.7 - 2020-08-22
 
 ### Added
 
@@ -116,6 +116,6 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Preplaced units are now assigned to a global variable.
 
-## v1.3.6
+## v1.3.6 - 2020-08-09
 
 _Initial version._

--- a/docs/changelogs/War3Net.Build.Core.changelog.md
+++ b/docs/changelogs/War3Net.Build.Core.changelog.md
@@ -4,23 +4,25 @@ All notable changes to the `War3Net.Build.Core` package, newest version first.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v6.0.3 - 2026-07-04
+## [Unreleased]
+
+## [v6.0.3] - 2026-07-04
 
 ### Changed
 
 - Updated `War3Net.IO.Mpq` from v6.0.2 to v6.0.3.
 
-## v6.0.2 - 2026-03-01
+## [v6.0.2] - 2026-03-01
 
 ### Breaking Changes
 
 - Updated target framework from .NET 5.0 to .NET 6.0.
 
-## v6.0.1 - 2026-02-01
+## [v6.0.1] - 2026-02-01
 
 _No functional changes; package readme and metadata updated for nuget.org presentation._
 
-## v6.0.0 - 2026-01-25
+## [v6.0.0] - 2026-01-25
 
 ### Breaking Changes
 
@@ -119,3 +121,9 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 ## v1.3.6 - 2020-08-09
 
 _Initial version._
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.3]: https://github.com/Drake53/War3Net/releases/tag/v6.0.3
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25

--- a/docs/changelogs/War3Net.Build.Core.changelog.md
+++ b/docs/changelogs/War3Net.Build.Core.changelog.md
@@ -42,6 +42,365 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Fixed exception when deserializing `MapInfo.EditorVersion` as JSON string.
 
+## v5.8.2 - 2025-09-27
+
+### Added
+
+- Added the game build data for patch 2.0.3 that was still missing after v5.8.0 (#82).
+
+## [v5.8.1] - 2025-09-12
+
+### Changed
+
+- Updated `War3Net.IO.Mpq` and `War3Net.IO.Slk` from v5.8.0 to v5.8.1.
+
+### Fixed
+
+- Parsing a map with an unknown editor version no longer throws (#77).
+
+## [v5.8.0] - 2025-09-06
+
+### Added
+
+- Added support for patch 2.0.3, and added the latest game patches and build data (#68, #73).
+- Added support for Linux/WSL, including case-insensitive path handling (#69).
+- Backported general improvements from the vJASS branch (#71).
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass`, `War3Net.IO.Mpq`, and `War3Net.IO.Slk` from v5.6.1 to v5.8.0.
+
+## v5.7.1 - 2023-01-19
+
+### Fixed
+
+- Fixed `MapBuilder` not adding skin object data files to the MPQ archive.
+
+## v5.7.0 - 2023-01-08
+
+### Breaking Changes
+
+- Merged the separate map and campaign classes that held identical data into a single class each.
+- The JSON deserialization methods no longer take a `TriggerData` parameter; it is only needed for binary deserialization.
+- Moved `CampaignExtensions` into this package.
+
+### Added
+
+- Added `SkinObjectData` to the `Map` and `Campaign` classes.
+- Added `FileExtension` constants.
+- Added binary read/write extension methods for `MapCustomTextTriggers` that use the default encoding.
+
+## v5.6.1 - 2023-01-07
+
+### Added
+
+- Added JSON serialization and deserialization support for the remaining `War3Net.Build.Core` types, including `MapTriggers`, backed by a set of custom `JsonConverter`s.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass`, `War3Net.IO.Mpq`, and `War3Net.IO.Slk` from v5.6.0 to v5.6.1.
+
+### Fixed
+
+- Fixed JSON serialization of `UnitData.RandomData`, and JSON deserialization of `UnitData`, `DoodadData`, and `TerrainTile`.
+
+## v5.6.0 - 2022-12-20
+
+### Breaking Changes
+
+- Renamed the format version enum members for consistency.
+
+### Added
+
+- Added JSON serialization and deserialization for `MapInfo`, including `JsonMapInfoConverter` and a `JsonSerializerOptions` parameter on the serialize methods.
+- Added patches 1.34.0 and 1.35.0 to `GamePatch`, along with the new retail game builds.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` and `War3Net.IO.Mpq` from v5.5.5 to v5.6.0, and `War3Net.IO.Slk` from v5.5.6 to v5.6.0.
+
+## v5.5.7 - 2022-12-14
+
+### Added
+
+- Added `EditorVersion` v6115.
+
+## v5.5.6 - 2022-11-30
+
+### Changed
+
+- Updated `War3Net.IO.Slk` from v5.5.5 to v5.5.6.
+
+## v5.5.5 - 2022-11-13
+
+### Breaking Changes
+
+- Changed the underlying type of the `Tileset` enum to `byte`.
+
+### Added
+
+- Added `TerrainTypeProvider.GetDefaultTerrainType`.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass`, `War3Net.IO.Mpq`, and `War3Net.IO.Slk` from v5.5.3 to v5.5.5.
+
+## v5.5.4 - 2022-10-29
+
+### Breaking Changes
+
+- Changed the underlying type of the `ImportedFileFlags` enum to `byte`.
+
+## v5.5.3 - 2022-10-29
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass`, `War3Net.IO.Mpq`, and `War3Net.IO.Slk` from v5.5.2 to v5.5.3.
+
+## v5.5.2 - 2022-10-25
+
+### Added
+
+- Added support for reading and writing `.wgc` (campaign gameplay constants) files.
+- Added the new 1.33.0 game builds.
+- Added missing filenames to the `DiscoverFileNames` extension method.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass`, `War3Net.IO.Mpq`, and `War3Net.IO.Slk` from v5.5.0 to v5.5.2.
+
+## v5.5.1 - 2022-08-23
+
+### Added
+
+- Added the `war3mapSkin` filenames to the `DiscoverFileNames` extension method.
+
+### Fixed
+
+- Fixed a bug in the `ObjectDataFormatVersion` v3 support added in v5.5.0.
+
+## v5.5.0 - 2022-08-20
+
+### Added
+
+- Added support for patch 1.33.0 and the reforged world editor versions.
+- Added support for `ObjectDataFormatVersion` v3.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` and `War3Net.IO.Mpq` from v5.4.5 to v5.5.0, and `War3Net.IO.Slk` from v5.4.0 to v5.5.0.
+
+## v5.4.5 - 2022-05-27
+
+### Breaking Changes
+
+- Changed `MapInfo.EditorVersion` from `int` to the `EditorVersion` enum.
+- Replaced `GamePatchVersionProvider` with `GameBuildsProvider`, backed by a new `GameBuilds.json` resource.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.4.1 to v5.4.5, and `War3Net.IO.Mpq` from v5.4.3 to v5.4.5.
+
+### Fixed
+
+- Fixed a parse error for `MapFlags`.
+
+## v5.4.4 - 2022-05-23
+
+### Fixed
+
+- Fixed `.w3f` (campaign info) parsing.
+
+## v5.4.3 - 2022-04-25
+
+### Fixed
+
+- Fixed an `ObjectDisposedException` on `MpqFile.MpqStream.BaseStream` when the `MpqFile` was created through the map extension methods.
+
+## v5.4.2 - 2022-04-24
+
+### Changed
+
+- Updated `War3Net.IO.Mpq` from v5.4.0 to v5.4.3.
+
+### Fixed
+
+- `ObjectDataModification` no longer uses `ValueAsBool`/`ValueAsChar`, which produced incorrect values for some object data types.
+
+## v5.4.1 - 2022-02-13
+
+### Added
+
+- Moved `MapBuilder` into this package.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.4.0 to v5.4.1.
+
+## v5.4.0 - 2022-02-13
+
+### Added
+
+- Added `TriggerRenderer`, for rendering `MapTriggers` back to a script.
+- `MapScriptBuilder` now uses the newly identified sound properties, and generates enemy priority flags for `PlayerData`.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` and `War3Net.IO.Mpq` from v5.3.0 to v5.4.0, and `War3Net.IO.Slk` from v0.1.3 to v5.4.0.
+
+### Fixed
+
+- Fixed the player colors.
+- Fixed `MapScriptBuilder` global variable generation.
+
+## v5.3.2 - 2022-01-16
+
+### Fixed
+
+- Fixed parsing of the 1.31.1 `triggerdata.txt`.
+
+## v5.3.1 - 2022-01-16
+
+### Added
+
+- Added patch v1.32.10 to `GamePatch`.
+- Added an extension method to read `TriggerData` from a `StringReader`.
+
+### Fixed
+
+- Fixed an exception thrown by `SingleOrDefault` in the `MpqArchiveBuilder` extension methods.
+
+## v5.3.0 - 2022-01-16
+
+### Breaking Changes
+
+- Changed the nullability of `Map` and `Campaign.Info`, and refactored `TriggerData`.
+- `TriggerFunction.Branch` is now a nullable `int`.
+- Renamed a previously unknown `TriggerCategoryDefinition` property.
+
+### Added
+
+- Added `MapFiles` and `CampaignFiles` enums, so only selected files need to be parsed, plus `Map.TryOpen`/`Campaign.TryOpen` methods and support for reading a campaign from a folder.
+- Added `MapFactory`, for creating a new `MapInfo`, `MapEnvironment`, and `MapPreviewIcons`.
+- Added `KnownPlayerColor` enum, `FileExtension`-style constants for `war3map.j`/`war3map.lua`, and an extension method to localize the strings in `MapInfo`.
+- Added `MapScriptBuilder.InitGlobals`, and support for decompiling custom variable types, the map initialization event, and `MapImportedFiles`.
+- Most `War3Net.Build.Core` classes now override `ToString()`.
+- Added `War3Net.IO.Slk` (v0.1.3) as a dependency, and the `UnitUI.slk` resource.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.2.2 to v5.3.0, and `War3Net.IO.Mpq` from v5.1.3 to v5.3.0.
+
+### Fixed
+
+- Fixed reading and writing `war3map.w3s` sounds in the reforged file format.
+- `MapTriggers` no longer throws when `TriggerItemCount` is incorrect.
+- Fixed `MapScriptBuilder` passing the wrong `SetGamePlacement` argument in the `config` function.
+- Fixed a `NullReferenceException` by setting `AllyPriorityFlags` in the constructor, and added a `PlayerData(int)` constructor.
+
+## v5.2.2 - 2021-02-16
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.2.1 to v5.2.2.
+
+## v5.2.1 - 2021-02-16
+
+### Added
+
+- Added `MapScriptBuilder` methods to generate the C# API for generated global variables.
+- Added `SetPlayers` extension method.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.0.0 to v5.2.1, and `War3Net.IO.Mpq` from v5.0.0 to v5.1.3.
+
+## v5.2.0 - 2021-02-14
+
+### Breaking Changes
+
+- Removed the old `MapBuilder`, replaced by a new `MapBuilder` built on top of `MapScriptBuilder`; `LegacyMapBuilder` is re-implemented on top of it.
+
+### Added
+
+- Added `MapScriptBuilder` (initially `MapScriptFactory`), which generates a map's script from its data files, including variable generators and a `Build` method.
+- Added extension methods to get and set campaign/map files, with overloads taking `Encoding` and `TriggerStrings` parameters.
+- Added `War3Net.CodeAnalysis.Jass` (v5.0.0) as a dependency.
+
+### Fixed
+
+- Fixed `LegacyMapBuilder` using `TopDirectoryOnly` when adding asset files, so files in subfolders are now included.
+
+## v5.1.0 - 2020-12-25
+
+### Added
+
+- Added `ImportedFiles` and `Script` to the `Campaign` and `Map` classes.
+- Added `SaveWithPreArchiveData` extension method overloads taking an `MpqArchiveCreateOptions` parameter.
+
+### Changed
+
+- Updated `War3Net.IO.Mpq` from v1.2.2 to v5.0.0.
+
+### Fixed
+
+- Fixed inconsistent casing across several public members.
+
+## v5.0.0 - 2020-12-14
+
+### Breaking Changes
+
+- All map and campaign data classes have been rewritten: parsing and serialization now live in binary reader/writer extension methods instead of on the classes themselves, and the classes are plain mutable data objects.
+- Renamed the environment classes for consistency, and removed the obsolete file-based API.
+- `MapEnvironment.Width`/`Height` are now one less than before, matching the world editor.
+- Updated target framework from .NET Core 3.1 to .NET 5.0.
+
+### Added
+
+- Added `Map` and `Campaign` classes that hold all of a map's/campaign's files, with constructors for building them from scratch.
+- Added support for reading and writing `.imp` files.
+- Added `EditorVersion` enum, and support for more `.doo` file format versions.
+- Introduced `SubVersion` for `MapTriggers` and `MapCustomTextTriggers`.
+
+### Changed
+
+- Player ally priority flags now use a bitmask.
+- Updated `War3Net.IO.Mpq` from v1.1.1 to v1.2.2.
+
+## v1.7.2 - 2020-11-12
+
+### Changed
+
+- Updated `War3Net.IO.Mpq` from v1.2.1 to v1.2.2.
+
+## v1.7.1 - 2020-11-12
+
+### Changed
+
+- Updated `War3Net.IO.Mpq` from v1.2.0 to v1.2.1.
+
+## v1.7.0 - 2020-11-12
+
+### Added
+
+- Added `MpqArchiveBuilderExtensions`.
+
+## v1.6.0 - 2020-11-11
+
+### Added
+
+- Support parsing and serializing `.w3c` (cameras) files.
+- Support parsing and serializing `.wts` (trigger strings) files.
+- Added the extension methods from the Map Adapter project.
+
+### Changed
+
+- Updated `War3Net.Common` from v0.3.0 to v0.3.1.
+
+### Fixed
+
+- Fixed parsing protected `war3map.w3r` files.
+
 ## v1.5.3 - 2020-10-29
 
 ### Added
@@ -135,3 +494,5 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 [v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
 [v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
 [v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.8.1]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.12
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.Build.Core.changelog.md
+++ b/docs/changelogs/War3Net.Build.Core.changelog.md
@@ -1,71 +1,121 @@
 # War3Net.Build.Core Changelog
 
+All notable changes to the `War3Net.Build.Core` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## v6.0.3
-### Changes
-- Updated War3Net.IO.Mpq from v6.0.2 to v6.0.3.
+
+### Changed
+
+- Updated `War3Net.IO.Mpq` from v6.0.2 to v6.0.3.
 
 ## v6.0.2
-### Breaking changes
+
+### Breaking Changes
+
 - Updated target framework from .NET 5.0 to .NET 6.0.
 
 ## v6.0.1
-No functional changes; package readme and metadata updated for nuget.org presentation.
+
+_No functional changes; package readme and metadata updated for nuget.org presentation._
 
 ## v6.0.0
-### Breaking changes
-- The EscapedStringProvider class has been moved to War3Net.CodeAnalysis.Jass.
-### Changes
-- Added W3MathF class.
-### Bugfixes
-- Fixed exception when deserializing MapInfo.EditorVersion as JSON string.
+
+### Breaking Changes
+
+- The `EscapedStringProvider` class has been moved to `War3Net.CodeAnalysis.Jass`.
+
+### Added
+
+- Added `W3MathF` class.
+
+### Fixed
+
+- Fixed exception when deserializing `MapInfo.EditorVersion` as JSON string.
 
 ## v1.5.3
-### Changes
-- Add UseNewFormat property to MapCustomTextTriggers.
+
+### Added
+
+- Add `UseNewFormat` property to `MapCustomTextTriggers`.
 
 ## v1.5.2
-### Changes
-- Support parsing and serializing .wct files.
+
+### Added
+
+- Support parsing and serializing `.wct` files.
 
 ## v1.5.1
-### Changes
-- Add SoundFlags.UNK16 flag.
-### Bugfixes
-- Fix MapTriggers serializer for old format could serialize TriggerItemType.RootCategory items.
+
+### Added
+
+- Add `SoundFlags.UNK16` flag.
+
+### Fixed
+
+- Fix `MapTriggers` serializer for old format could serialize `TriggerItemType.RootCategory` items.
 
 ## v1.5.0
-### Changes
-- Support parsing and serializing .wtg files.
-- Support additional format versions of .w3i files.
+
+### Added
+
+- Support parsing and serializing `.wtg` files.
+- Support additional format versions of `.w3i` files.
+- Include 1.32.9 in `GamePatch` enum.
+
+### Changed
+
 - Update target framework from .NET Standard to .NET Core.
-- Include 1.32.9 in GamePatch enum.
 
 ## v1.4.0
-### Changes
-- Added GetTerrainTypes and GetCliffTypes methods to MapEnvironment.
-- Added GetGamePatch method to GamePatchVersionProvider.
-- Updated War3Net.IO.Mpq and CSharpLua packages.
-### Bugfixes
-- Fix parse error in war3mapUnits.doo when random data mode is -1.
-### Breaking changes
-- FileProvider class has been moved to War3Net.IO.Mpq namespace.
-- Renamed GamePatchVersionProvider.GetPatchVersion to GetGameVersion.
+
+### Breaking Changes
+
+- `FileProvider` class has been moved to `War3Net.IO.Mpq` namespace.
+- Renamed `GamePatchVersionProvider.GetPatchVersion` to `GetGameVersion`.
+
+### Added
+
+- Added `GetTerrainTypes` and `GetCliffTypes` methods to `MapEnvironment`.
+- Added `GetGamePatch` method to `GamePatchVersionProvider`.
+
+### Changed
+
+- Updated `War3Net.IO.Mpq` and `CSharpLua` packages.
+
+### Fixed
+
+- Fix parse error in `war3mapUnits.doo` when random data mode is -1.
 
 ## v1.3.10
-### Changes
-- Add event OnArchiveBuilding to MapBuilder.
+
+### Added
+
+- Add event `OnArchiveBuilding` to `MapBuilder`.
 
 ## v1.3.9
-### Bugfixes
+
+### Fixed
+
 - Fix lua global declarations.
 
 ## v1.3.8
-### Bugfixes
+
+### Fixed
+
 - Fix string interpolation uses incorrect format string.
 
 ## v1.3.7
-### Changes
-- Preplaced units are now assigned to a global variable.
-- Include 1.32.8 in GamePatch enum.
 
-## v1.3.6 - Initial Version
+### Added
+
+- Include 1.32.8 in `GamePatch` enum.
+
+### Changed
+
+- Preplaced units are now assigned to a global variable.
+
+## v1.3.6
+
+_Initial version._

--- a/docs/changelogs/War3Net.Build.Core.changelog.md
+++ b/docs/changelogs/War3Net.Build.Core.changelog.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+_No unreleased changes._
+
 ## [v6.0.3] - 2026-07-04
+
+### Added
+
+- Added .NET 10.0 target framework; the package now targets both .NET 6.0 and .NET 10.0.
 
 ### Changed
 
@@ -120,7 +126,9 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 ## v1.3.6 - 2020-08-09
 
-_Initial version._
+### Added
+
+- Initial release. Useful files were moved out of the `War3Net.Build` package into this new package, to reduce dependencies.
 
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.3]: https://github.com/Drake53/War3Net/releases/tag/v6.0.3

--- a/docs/changelogs/War3Net.Build.changelog.md
+++ b/docs/changelogs/War3Net.Build.changelog.md
@@ -4,23 +4,23 @@ All notable changes to the `War3Net.Build` package, newest version first.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v6.0.3
+## v6.0.3 - 2026-07-04
 
 ### Changed
 
 - Updated `War3Net.Build.Core` from v6.0.2 to v6.0.3.
 
-## v6.0.2
+## v6.0.2 - 2026-03-01
 
 ### Breaking Changes
 
 - Updated target framework from .NET 5.0 to .NET 6.0.
 
-## v6.0.1
+## v6.0.1 - 2026-02-01
 
 _No functional changes; package readme and metadata updated for nuget.org presentation._
 
-## v6.0.0
+## v6.0.0 - 2026-01-25
 
 ### Breaking Changes
 
@@ -28,7 +28,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 - `TriggerRenderer` and `TriggerRendererContext` now expect an `IndentedTextWriter` instead of `JassRenderer`/`TextWriter`.
 - `MapScriptBuilder`'s C# api methods have been removed, you can now use the `GenerateGlobals` methods and manually transpile to C#.
 
-## v1.5.0
+## v1.5.0 - 2020-10-27
 
 ### Added
 
@@ -40,7 +40,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Update target framework from .NET Standard to .NET Core.
 
-## v1.4.0
+## v1.4.0 - 2020-09-14
 
 ### Breaking Changes
 
@@ -60,13 +60,13 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Fix parse error in `war3mapUnits.doo` when random data mode is -1.
 
-## v1.3.10
+## v1.3.10 - 2020-08-30
 
 ### Added
 
 - Add event `OnArchiveBuilding` to `MapBuilder`.
 
-## v1.3.9
+## v1.3.9 - 2020-08-22
 
 ### Fixed
 
@@ -78,7 +78,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Fix string interpolation uses incorrect format string.
 
-## v1.3.7
+## v1.3.7 - 2020-08-22
 
 ### Added
 
@@ -88,7 +88,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Preplaced units are now assigned to a global variable.
 
-## v1.3.6
+## v1.3.6 - 2020-08-09
 
 ### Added
 
@@ -98,7 +98,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Created new project `War3Net.Build.Core`, and moved useful files there to reduce dependencies.
 
-## v1.3.5
+## v1.3.5 - 2020-07-11
 
 ### Added
 
@@ -113,7 +113,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Changed/added some exception messages.
 
-## v1.3.4
+## v1.3.4 - 2020-06-01
 
 ### Added
 
@@ -123,7 +123,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Updated `War3Net.CodeAnalysis.Jass`, `CSharpLua`, and `War3Api` packages.
 
-## v1.3.3
+## v1.3.3 - 2020-05-09
 
 ### Added
 
@@ -133,14 +133,14 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Added default value and property for `ObjectData` format version, so its value is not stuck at 0, which is invalid.
 
-## v1.3.2
+## v1.3.2 - 2020-04-25
 
 ### Added
 
 - Added setter indexer to `ObjectDataModification`.
 - Added property `MapObjectData` to `ScriptCompilerOptions`.
 
-## v1.3.1
+## v1.3.1 - 2020-04-21
 
 ### Changed
 
@@ -150,7 +150,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Can now run `MapBuilder`'s `Build` method multiple times, without needing to restart the application.
 
-## v1.3.0
+## v1.3.0 - 2020-04-12
 
 ### Added
 
@@ -165,14 +165,14 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - `CreateAllDestructables` can now generate the dead and withZ variants of `CreateDestructable`.
 
-## v1.2.0
+## v1.2.0 - 2020-03-08
 
 ### Added
 
 - Support `war3map.mmp` files.
 - Support water tinting color.
 
-## v1.1.4
+## v1.1.4 - 2020-03-04
 
 ### Added
 
@@ -183,26 +183,26 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Update `CSharpLua` to v1.5.10, and `War3Api` to v1.32.2.
 
-## v1.1.3
+## v1.1.3 - 2020-03-01
 
 ### Fixed
 
 - Fix `MapSounds` reforged file format was not parsed correctly.
 
-## v1.1.2
+## v1.1.2 - 2020-02-10
 
 ### Fixed
 
 - Fix `MapRegions` containing regions without sound generates invalid syntax.
 
-## v1.1.1
+## v1.1.1 - 2020-02-09
 
 ### Fixed
 
 - Replace `Regex.Escape`, which escapes too many characters (e.g. `.`).
 - Update `CSharpLua` to v1.5.9, which has some more bug fixes.
 
-## v1.1.0
+## v1.1.0 - 2020-02-08
 
 ### Breaking Changes
 
@@ -241,7 +241,7 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 - Can now parse and serialize `war3map.w3s` file format version 2. Meaning of the added data not yet known, nor stored in the `MapSounds` object.
 - Added overload for `PlayerData.Create` method, making it easier to create a copy of an existing playerData object.
 
-## v1.0.0
+## v1.0.0 - 2020-01-28
 
 ### Breaking Changes
 

--- a/docs/changelogs/War3Net.Build.changelog.md
+++ b/docs/changelogs/War3Net.Build.changelog.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+_No unreleased changes._
+
 ## [v6.0.3] - 2026-07-04
+
+### Added
+
+- Added .NET 10.0 target framework; the package now targets both .NET 6.0 and .NET 10.0.
 
 ### Changed
 

--- a/docs/changelogs/War3Net.Build.changelog.md
+++ b/docs/changelogs/War3Net.Build.changelog.md
@@ -1,157 +1,259 @@
 # War3Net.Build Changelog
 
+All notable changes to the `War3Net.Build` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## v6.0.3
-### Changes
-- Updated War3Net.Build.Core from v6.0.2 to v6.0.3.
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v6.0.2 to v6.0.3.
 
 ## v6.0.2
-### Breaking changes
+
+### Breaking Changes
+
 - Updated target framework from .NET 5.0 to .NET 6.0.
 
 ## v6.0.1
-No functional changes; package readme and metadata updated for nuget.org presentation.
+
+_No functional changes; package readme and metadata updated for nuget.org presentation._
 
 ## v6.0.0
-### Breaking changes
-- MapScriptBuilder methods have been renamed and now write to an IndentedTextWriter instead of returning a syntax class.
-- TriggerRenderer and TriggerRendererContext now expect an IndentedTextWriter instead of JassRenderer/TextWriter.
-- MapScriptBuilder's C# api methods have been removed, you can now use the GenerateGlobals methods and manually transpile to C#.
+
+### Breaking Changes
+
+- `MapScriptBuilder` methods have been renamed and now write to an `IndentedTextWriter` instead of returning a syntax class.
+- `TriggerRenderer` and `TriggerRendererContext` now expect an `IndentedTextWriter` instead of `JassRenderer`/`TextWriter`.
+- `MapScriptBuilder`'s C# api methods have been removed, you can now use the `GenerateGlobals` methods and manually transpile to C#.
 
 ## v1.5.0
-### Changes
-- Support parsing and serializing .wtg files.
-- Support additional format versions of .w3i files.
+
+### Added
+
+- Support parsing and serializing `.wtg` files.
+- Support additional format versions of `.w3i` files.
+- Include 1.32.9 in `GamePatch` enum.
+
+### Changed
+
 - Update target framework from .NET Standard to .NET Core.
-- Include 1.32.9 in GamePatch enum.
 
 ## v1.4.0
-### Changes
-- Added GetTerrainTypes and GetCliffTypes methods to MapEnvironment.
-- Added GetGamePatch method to GamePatchVersionProvider.
-- Updated War3Net.IO.Mpq and CSharpLua packages.
-### Bugfixes
-- Fix parse error in war3mapUnits.doo when random data mode is -1.
-### Breaking changes
-- FileProvider class has been moved to War3Net.IO.Mpq namespace.
-- Renamed GamePatchVersionProvider.GetPatchVersion to GetGameVersion.
+
+### Breaking Changes
+
+- `FileProvider` class has been moved to `War3Net.IO.Mpq` namespace.
+- Renamed `GamePatchVersionProvider.GetPatchVersion` to `GetGameVersion`.
+
+### Added
+
+- Added `GetTerrainTypes` and `GetCliffTypes` methods to `MapEnvironment`.
+- Added `GetGamePatch` method to `GamePatchVersionProvider`.
+
+### Changed
+
+- Updated `War3Net.IO.Mpq` and `CSharpLua` packages.
+
+### Fixed
+
+- Fix parse error in `war3mapUnits.doo` when random data mode is -1.
 
 ## v1.3.10
-### Changes
-- Add event OnArchiveBuilding to MapBuilder.
+
+### Added
+
+- Add event `OnArchiveBuilding` to `MapBuilder`.
 
 ## v1.3.9
-### Bugfixes
+
+### Fixed
+
 - Fix lua global declarations.
 
 ## v1.3.8
-### Bugfixes
+
+### Fixed
+
 - Fix string interpolation uses incorrect format string.
 
 ## v1.3.7
-### Changes
+
+### Added
+
+- Include 1.32.8 in `GamePatch` enum.
+
+### Changed
+
 - Preplaced units are now assigned to a global variable.
-- Include 1.32.8 in GamePatch enum.
 
 ## v1.3.6
-### Changes
-- Created new project 'War3Net.Build.Core', and moved useful files there to reduce dependencies.
-- Include 1.32.6 and 1.32.7 in GamePatch enum.
+
+### Added
+
+- Include 1.32.6 and 1.32.7 in `GamePatch` enum.
+
+### Changed
+
+- Created new project `War3Net.Build.Core`, and moved useful files there to reduce dependencies.
 
 ## v1.3.5
-### Changes
-- Can now parse and serialize war3map.w3s file format version 3. Meaning of the added data not yet known, nor stored in the MapSounds object.
+
+### Added
+
+- Can now parse and serialize `war3map.w3s` file format version 3. Meaning of the added data not yet known, nor stored in the `MapSounds` object.
+
+### Changed
+
 - Object data file parsers no longer validate the object modifications.
-- Updated War3Net.Common and War3Net.IO.Mpq packages.
-### Bugfixes
+- Updated `War3Net.Common` and `War3Net.IO.Mpq` packages.
+
+### Fixed
+
 - Changed/added some exception messages.
 
 ## v1.3.4
-### Changes
-- Added DecompilePackageLibs to ScriptCompilerOptions.
-- Updated War3Net.CodeAnalysis.Jass, CSharpLua, and War3Api packages.
+
+### Added
+
+- Added `DecompilePackageLibs` to `ScriptCompilerOptions`.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass`, `CSharpLua`, and `War3Api` packages.
 
 ## v1.3.3
-### Changes
-- Include latest Reforged patches in GamePatch enum.
-### Bugfixes
-- Added default value and property for ObjectData format version, so its value is not stuck at 0, which is invalid.
+
+### Added
+
+- Include latest Reforged patches in `GamePatch` enum.
+
+### Fixed
+
+- Added default value and property for `ObjectData` format version, so its value is not stuck at 0, which is invalid.
 
 ## v1.3.2
-### Changes
-- Added setter indexer to ObjectDataModification.
-- Added property MapObjectData to ScriptCompilerOptions.
+
+### Added
+
+- Added setter indexer to `ObjectDataModification`.
+- Added property `MapObjectData` to `ScriptCompilerOptions`.
 
 ## v1.3.1
-### Changes
-- Update CSharpLua and MPQ packages.
-### Bugfixes
-- Can now run MapBuilder's Build method multiple times, without needing to restart the application.
+
+### Changed
+
+- Update `CSharpLua` and MPQ packages.
+
+### Fixed
+
+- Can now run `MapBuilder`'s `Build` method multiple times, without needing to restart the application.
 
 ## v1.3.0
-### Changes
-- Support .w3u, .w3t, .w3b, .w3d, .w3a, .w3h, .w3q, .w3o, and .w3f files.
-- Added ObjectData and TargetPatch properties to ScriptCompilerOptions. Not setting the TargetPatch will generate a new warning diagnostic.
-- FileProvider can now search recursively in MPQ archives (useful for campaigns). Also added FileExists method.
-- CreateAllDestructables can now generate the dead and withZ variants of CreateDestructable.
-- Added property HasSkin to unit and doodad data.
-- Include latest Reforged patches in GamePatch enum.
-- Added SetGameVersion method to MapInfo.
+
+### Added
+
+- Support `.w3u`, `.w3t`, `.w3b`, `.w3d`, `.w3a`, `.w3h`, `.w3q`, `.w3o`, and `.w3f` files.
+- Added `ObjectData` and `TargetPatch` properties to `ScriptCompilerOptions`. Not setting the `TargetPatch` will generate a new warning diagnostic.
+- `FileProvider` can now search recursively in MPQ archives (useful for campaigns). Also added `FileExists` method.
+- Added property `HasSkin` to unit and doodad data.
+- Include latest Reforged patches in `GamePatch` enum.
+- Added `SetGameVersion` method to `MapInfo`.
+
+### Changed
+
+- `CreateAllDestructables` can now generate the dead and withZ variants of `CreateDestructable`.
 
 ## v1.2.0
-### Changes
-- Support war3map.mmp files.
+
+### Added
+
+- Support `war3map.mmp` files.
 - Support water tinting color.
 
 ## v1.1.4
-### Changes
-- Added setters for Sound properties.
-- Added get/set methods in MapSounds to handle sound collection.
-- Update CSharpLua to v1.5.10, and War3Api to v1.32.2
+
+### Added
+
+- Added setters for `Sound` properties.
+- Added get/set methods in `MapSounds` to handle sound collection.
+
+### Changed
+
+- Update `CSharpLua` to v1.5.10, and `War3Api` to v1.32.2.
 
 ## v1.1.3
-### Bugfixes
-- Fix MapSounds reforged file format was not parsed correctly.
+
+### Fixed
+
+- Fix `MapSounds` reforged file format was not parsed correctly.
 
 ## v1.1.2
-### Bugfixes
-- Fix MapRegions containing regions without sound generates invalid syntax.
+
+### Fixed
+
+- Fix `MapRegions` containing regions without sound generates invalid syntax.
 
 ## v1.1.1
-### Bugfixes
-- Replace Regex.Escape, which escapes too many characters (eg '.').
-- Update CSharpLua to v1.5.9, which has some more bug fixes.
+
+### Fixed
+
+- Replace `Regex.Escape`, which escapes too many characters (e.g. `.`).
+- Update `CSharpLua` to v1.5.9, which has some more bug fixes.
 
 ## v1.1.0
-### Changes
-- Default FormatVersion for MapInfo set back to v1.31 format.
-- MapInfo property setters will now check if the property is available for the current FormatVersion.
-- Added FormatVersion enum and property for all map files.
+
+### Breaking Changes
+
+- `MapSounds` constructor now takes `MapSoundsFormatVersion` instead of `uint`.
+
+### Added
+
+- Added `FormatVersion` enum and property for all map files.
+- Added `GamePatch` enum.
+
+### Changed
+
+- Default `FormatVersion` for `MapInfo` set back to v1.31 format.
+- `MapInfo` property setters will now check if the property is available for the current `FormatVersion`.
 - Map script generator will set unit/item/destructable skin if it's different from its type ID.
-- Added GamePatch enum.
-### Bugfixes
-- MapDoodads is now parsed correctly, similar to MapUnits.
-### Breaking changes
-- MapSounds constructor now takes MapSoundsFormatVersion instead of uint.
+
+### Fixed
+
+- `MapDoodads` is now parsed correctly, similar to `MapUnits`.
 
 ## v1.0.2
-### Changes
+
+### Breaking Changes
+
+- Subversion type for `.doo` headers changed from `uint` to `MapWidgetsSubVersion` enum.
+
+### Added
+
 - Added reforged sound channels (not tested).
-- Added setters for most MapUnits properties, and added the Skin property.
-### Breaking changes
-- Subversion type for .doo headers changed from uint to MapWidgetsSubVersion enum.
+- Added setters for most `MapUnits` properties, and added the `Skin` property.
 
 ## v1.0.1
-### Changes
-- Can now parse and serialize war3map.w3s file format version 2. Meaning of the added data not yet known, nor stored in the MapSounds object.
-- Added overload for PlayerData.Create method, making it easier to create a copy of an existing playerData object.
+
+### Added
+
+- Can now parse and serialize `war3map.w3s` file format version 2. Meaning of the added data not yet known, nor stored in the `MapSounds` object.
+- Added overload for `PlayerData.Create` method, making it easier to create a copy of an existing playerData object.
 
 ## v1.0.0
-### Changes
-- Updated War3Api and MapInfo.Default for reforged.
-### Bugfixes
-- Unit and doodad rotation data from .doo files is now correctly converted from radians to degrees.
-- MapUnits and MapDoodads IEnumerable constructor now sets the .doo header to its default value.
-- Sounds paths in war3map.w3s files are now correctly escaped.
-### Breaking changes
-- Strings from MapInfo.MapName, MapInfo.MapDescription, and Options.LobbyMusic are now automatically escaped in the map script.
-	- This change introduced a bug, that has been fixed in v1.1.1
+
+### Breaking Changes
+
+- Strings from `MapInfo.MapName`, `MapInfo.MapDescription`, and `Options.LobbyMusic` are now automatically escaped in the map script.
+  - This change introduced a bug, that has been fixed in v1.1.1.
+
+### Changed
+
+- Updated `War3Api` and `MapInfo.Default` for reforged.
+
+### Fixed
+
+- Unit and doodad rotation data from `.doo` files is now correctly converted from radians to degrees.
+- `MapUnits` and `MapDoodads` `IEnumerable` constructor now sets the `.doo` header to its default value.
+- Sounds paths in `war3map.w3s` files are now correctly escaped.

--- a/docs/changelogs/War3Net.Build.changelog.md
+++ b/docs/changelogs/War3Net.Build.changelog.md
@@ -36,6 +36,226 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 - `TriggerRenderer` and `TriggerRendererContext` now expect an `IndentedTextWriter` instead of `JassRenderer`/`TextWriter`.
 - `MapScriptBuilder`'s C# api methods have been removed, you can now use the `GenerateGlobals` methods and manually transpile to C#.
 
+## v5.8.2 - 2025-09-27
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.8.1 to v5.8.2.
+
+## [v5.8.1] - 2025-09-12
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.8.0 to v5.8.1.
+
+## [v5.8.0] - 2025-09-06
+
+### Added
+
+- Added support for Linux/WSL, including case-insensitive path handling (#69).
+- Backported general improvements from the vJASS branch (#71).
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.7.1 to v5.8.0, and `War3Net.CodeAnalysis.Transpilers` from v5.6.1 to v5.8.0.
+
+## v5.7.1 - 2023-01-19
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.7.0 to v5.7.1.
+
+## v5.7.0 - 2023-01-08
+
+### Breaking Changes
+
+- Followed the `War3Net.Build.Core` v5.7.0 merge of the separate map and campaign classes that held identical data.
+
+### Added
+
+- Added `CampaignExtensions.GetInfoFile`, `GetImportedFilesFile`, `SetImportedFilesFile`, and `LocalizeInfo`, matching the methods already available on `MapExtensions`.
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.6.1 to v5.7.0.
+
+## v5.6.1 - 2023-01-07
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Transpilers` from v5.6.0 to v5.6.1.
+
+## v5.6.0.1 - 2022-12-28
+
+### Fixed
+
+- Fixed a `NullReferenceException` in `MapScriptBuilder`.
+
+## v5.6.0 - 2022-12-20
+
+### Breaking Changes
+
+- Renamed the format version enum members for consistency, following `War3Net.Build.Core` v5.6.0.
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.5.7 to v5.6.0, and `War3Net.CodeAnalysis.Transpilers` from v5.5.5 to v5.6.0.
+
+### Fixed
+
+- Fixed the `MapScriptBuilder` check for whether 24 players are supported.
+
+## v5.5.7 - 2022-12-14
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.5.6 to v5.5.7.
+
+## v5.5.6 - 2022-11-30
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.5.5 to v5.5.6.
+
+## v5.5.5 - 2022-11-13
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Transpilers` from v5.5.3 to v5.5.5.
+
+## v5.5.3 - 2022-10-29
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Transpilers` from v5.5.2 to v5.5.3.
+
+## v5.5.2 - 2022-10-25
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Transpilers` from v5.5.0 to v5.5.2.
+
+## v5.5.0 - 2022-08-20
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Transpilers` from v5.4.5 to v5.5.0.
+
+## v5.4.5 - 2022-05-27
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.4.2 to v5.4.5, and `War3Net.CodeAnalysis.Transpilers` from v5.4.1 to v5.4.5.
+- Adapted to the `GamePatchVersionProvider` to `GameBuildsProvider` replacement in `War3Net.Build.Core` v5.4.5.
+
+## v5.4.2 - 2022-04-24
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.4.1 to v5.4.2.
+
+### Fixed
+
+- `UnitDataExtensions` no longer uses `ValueAsBool`/`ValueAsChar`, which produced incorrect values for some object data types.
+
+## v5.4.1 - 2022-02-13
+
+### Breaking Changes
+
+- `MapBuilder` has been moved to `War3Net.Build.Core`.
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Transpilers` from v5.4.0 to v5.4.1.
+
+## v5.4.0 - 2022-02-13
+
+### Added
+
+- Added `TriggerRenderer`, for rendering `MapTriggers` back to a script, including support for Lua triggers.
+- `MapScriptBuilder` now detects units referenced by triggers, and generates destructable global variables.
+- `MapScriptBuilder` now uses the newly identified sound properties, and generates enemy priority flags for `PlayerData`.
+
+### Changed
+
+- `RenderAction`/`RenderCondition` take a `TriggerFunctionParameter` instead of a `TriggerFunction`.
+- `UnitDataExtensions.IsBuilding` now checks the unit object data.
+- Updated `War3Net.Build.Core` from v5.3.0 to v5.4.0, and `War3Net.CodeAnalysis.Transpilers` from v5.2.8 to v5.4.0.
+
+### Fixed
+
+- Fixed `MapScriptBuilder` global and widget variable generation, and a trigger naming bug.
+
+## v5.3.0 - 2022-01-16
+
+### Added
+
+- `MapScriptBuilder` now generates trigger functions, `InitGlobals`, and user-defined global variables, and handles the `InitCustomTeams` special case where the function is generated but never invoked.
+- Added support for decompiling `MapImportedFiles`, and constants for `war3map.j` and `war3map.lua`.
+
+### Changed
+
+- Added null checks for `MapInfo` and `MapEnvironment` throughout.
+- Updated `War3Net.Build.Core` from v5.2.2 to v5.3.0.
+
+### Fixed
+
+- Fixed `MapScriptBuilder` handling of sounds with the `Music` flag, unit creation functions, `CreateNeutralPassive`, unit method conditions, and the `SetGamePlacement` argument in the `config` function.
+- Fixed `MapExtensions.SetFile` for script files.
+- `CreateCameras` now checks the new file format.
+
+## v5.0.4 - 2021-04-09
+
+### Added
+
+- `MapScriptBuilder` now generates the tech tree and upgrades.
+
+## v5.0.3 - 2021-04-08
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Transpilers` from v5.2.7 to v5.2.8.
+
+## v5.0.2 - 2021-04-07
+
+### Fixed
+
+- Fixed the `war3mapUnits.doo` case being unreachable because the switch was case-sensitive.
+
+## v5.0.1 - 2021-04-06
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Transpilers` from v5.2.6 to v5.2.7.
+
+## v5.0.0 - 2021-03-06
+
+### Breaking Changes
+
+- Removed the old `MapBuilder` and the obsolete script builder classes; map scripts are now generated through `MapScriptBuilder` and the new `MapBuilder`, with `LegacyMapBuilder` re-implemented on top of it.
+- Removed the `War3Api` dependency, and replaced the `War3Net.CodeAnalysis.Jass` dependency with `War3Net.CodeAnalysis.Transpilers` (v5.2.6).
+- Updated target framework from .NET Core 3.1 to .NET 5.0.
+
+### Added
+
+- Added extension methods to get and set campaign/map files, and more constants.
+- Added support for the new package decompile options, `ScriptCompilerOptions.LobbyMusic`, and setting `compiler.IsExportMetadata`.
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v1.5.3 to v5.2.2.
+
+### Fixed
+
+- Fixed `LegacyMapBuilder` using `TopDirectoryOnly` when adding asset files, so files in subfolders are now included.
+- Fixed being unable to set a map's `Info`/`Environment` through the `SetFile` extension method when they were null.
+
+## v1.7.0 - 2020-11-12
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v1.5.0 to v1.5.3.
+
 ## v1.5.0 - 2020-10-27
 
 ### Added
@@ -266,8 +486,53 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 - `MapUnits` and `MapDoodads` `IEnumerable` constructor now sets the `.doo` header to its default value.
 - Sounds paths in `war3map.w3s` files are now correctly escaped.
 
+## v0.2.1 - 2019-10-21
+
+### Added
+
+- Added `ScriptCompilerOptions(IEnumerable<string>)` constructor.
+
+### Changed
+
+- The CSharp.lua CoreSystem libraries are no longer imported into the compilation automatically; `ScriptCompilerOptions.Libraries` is used as-is.
+
+## v0.2.0 - 2019-10-21
+
+### Added
+
+- Added `TerrainType` enum.
+
+### Changed
+
+- Updated the `War3Net.CSharpLua` dependency from v1.1.2 to the floating v1.2.* range.
+
+## v0.1.2 - 2019-10-16
+
+### Changed
+
+- Updated the `War3Net.CSharpLua` package version.
+
+## v0.1.1 - 2019-10-16
+
+### Fixed
+
+- Fixed the dependency on the CSharp.lua project not being declared correctly when packing.
+
+## v0.1.0 - 2019-10-15
+
+### Added
+
+- Initial release, for building a Warcraft III map file from source:
+  - `MapBuilder`, for assembling a map from its data files and assets, including loading assets from MPQ archives.
+  - `ScriptCompiler` and `ScriptCompilerOptions`, for compiling a map script from JASS, Lua, or C#, with support for importing custom Lua libraries and compiling C# in debug mode.
+  - `FunctionBuilder` classes, for generating the `main` and `config` functions.
+  - Parsing and serialization for the `war3map.w3i` file, with methods to manipulate player and force settings.
+  - `Tileset` enum, provider classes for light and sound environments, and `FileProvider` with locale support.
+
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.3]: https://github.com/Drake53/War3Net/releases/tag/v6.0.3
 [v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
 [v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
 [v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.8.1]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.12
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.Build.changelog.md
+++ b/docs/changelogs/War3Net.Build.changelog.md
@@ -4,23 +4,25 @@ All notable changes to the `War3Net.Build` package, newest version first.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v6.0.3 - 2026-07-04
+## [Unreleased]
+
+## [v6.0.3] - 2026-07-04
 
 ### Changed
 
 - Updated `War3Net.Build.Core` from v6.0.2 to v6.0.3.
 
-## v6.0.2 - 2026-03-01
+## [v6.0.2] - 2026-03-01
 
 ### Breaking Changes
 
 - Updated target framework from .NET 5.0 to .NET 6.0.
 
-## v6.0.1 - 2026-02-01
+## [v6.0.1] - 2026-02-01
 
 _No functional changes; package readme and metadata updated for nuget.org presentation._
 
-## v6.0.0 - 2026-01-25
+## [v6.0.0] - 2026-01-25
 
 ### Breaking Changes
 
@@ -257,3 +259,9 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 - Unit and doodad rotation data from `.doo` files is now correctly converted from radians to degrees.
 - `MapUnits` and `MapDoodads` `IEnumerable` constructor now sets the `.doo` header to its default value.
 - Sounds paths in `war3map.w3s` files are now correctly escaped.
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.3]: https://github.com/Drake53/War3Net/releases/tag/v6.0.3
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25

--- a/docs/changelogs/War3Net.CodeAnalysis.Decompilers.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.Decompilers.changelog.md
@@ -6,43 +6,181 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+_No unreleased changes._
+
 ## [v6.0.3] - 2026-07-04
+
+### Added
+
+- Added .NET 10.0 target framework; the package now targets both .NET 6.0 and .NET 10.0.
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v6.0.2 to v6.0.3.
 
 ## [v6.0.2] - 2026-03-01
 
+### Breaking Changes
+
+- Updated target framework from .NET 5.0 to .NET 6.0.
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Jass` from v6.0.1 to v6.0.2.
+
 ## [v6.0.1] - 2026-02-01
+
+_No functional changes; package readme and metadata updated for nuget.org presentation._
 
 ## [v6.0.0] - 2026-01-25
 
+### Breaking Changes
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.8.0 to v6.0.0. The `TryDecompile*` overloads that take a `JassFunctionDeclarationSyntax` now expect the redesigned syntax classes; those breaking changes have been documented in [the migration guide](../guides/jass-migration-guide-v5-to-v6.md).
+- Updated `War3Net.Build.Core` from v5.8.2 to v6.0.0.
+
+### Changed
+
+- Comments and blank lines are now read from syntax trivia instead of being handled as statements, following the syntax tree redesign in `War3Net.CodeAnalysis.Jass` v6.0.0.
+
 ## v5.8.2 - 2025-09-27
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.8.1 to v5.8.2.
 
 ## [v5.8.1] - 2025-09-12
 
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.8.0 to v5.8.1.
+
 ## [v5.8.0] - 2025-09-06
+
+### Breaking Changes
+
+- `TryDecompileMapUnits(JassFunctionDeclarationSyntax, ...)` takes an additional `createAllItemsFunction` parameter, and the parameterless-function overload now also requires the script to contain a `CreateAllItems` function.
+
+### Added
+
+- Preplaced items are now decompiled from the `CreateAllItems` function into `war3mapUnits.doo`, supporting both `CreateItem` and `BlzCreateItemWithSkin` calls (#54).
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.7.1 to v5.8.0, and `War3Net.CodeAnalysis.Jass` from v5.6.1 to v5.8.0.
+
+### Fixed
+
+- Decompiled units, items, and start locations are now assigned an incrementing `CreationNumber` instead of all sharing the same default value (#53).
 
 ## v5.7.1 - 2023-01-19
 
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.7.0 to v5.7.1.
+
 ## v5.7.0 - 2023-01-08
+
+### Breaking Changes
+
+- `TryDecompileMapImportedFiles` now outputs an `ImportedFiles` instead of a `MapImportedFiles`, following the merge of the map and campaign classes in `War3Net.Build.Core` v5.7.0.
+
+### Changed
+
+- Updated `War3Net.Build.Core` from v5.6.1 to v5.7.0.
+
+### Fixed
+
+- The imported files decompiler now also ignores the map's skin object data files, so they are no longer listed as imported files.
 
 ## v5.6.1 - 2023-01-07
 
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Jass` from v5.6.0 to v5.6.1.
+
 ## v5.6.0 - 2022-12-20
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Jass` from v5.5.5 to v5.6.0.
 
 ## v5.5.5 - 2022-11-13
 
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Jass` from v5.5.3 to v5.5.5.
+
 ## v5.5.3 - 2022-10-29
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Jass` from v5.5.2 to v5.5.3.
 
 ## v5.5.2 - 2022-10-25
 
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Jass` from v5.5.0 to v5.5.2.
+
 ## v5.5.0 - 2022-08-20
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Jass` from v5.4.5 to v5.5.0.
 
 ## v5.4.5 - 2022-05-27
 
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Jass` from v5.4.1 to v5.4.5.
+
 ## v5.4.2 - 2022-02-18
+
+### Added
+
+- Added dedicated decompilers for the individual JASS syntax kinds (unary, binary and parenthesized expressions, all literal kinds, function and variable references, and `set`/`call`/`if`/`loop`/`return` statements), widening the range of scripts that can be decompiled into GUI triggers.
+- Support decompiling the `IfThenElse` action, in addition to the already supported `IfThenElseMultiple`.
+- Support decompiling the `WaitForCondition` and `ReturnAction` actions.
+- Hero attributes are now decompiled from `SetHeroStr`, `SetHeroAgi`, and `SetHeroInt` calls into `UnitData`.
+
+### Changed
+
+- `TriggerDataContext.TriggerParams` now contains an additional entry, keyed by `string.Empty`, holding the trigger params of all variable types.
+- Trigger conditions functions are now decompiled through the same code path as the statement lists of other functions.
+
+### Fixed
+
+- Fixed `NullReferenceException` in `TryDecompileMapUnits` when the script does not contain a `CreateAllUnits`, `config`, or `InitCustomPlayerSlots` function; it now returns `false`.
+- Fixed `KeyNotFoundException` when decompiling a call to a function that is not present in the trigger data.
+- Fixed string literals not being decompiled to a string parameter when the trigger data contains no custom string types.
+- Fixed variable and array reference expressions being decompiled incorrectly when multiple matching trigger params were found.
 
 ## v5.4.1 - 2022-02-13
 
+### Added
+
+- Added `TryDecompileMapUnits`, which decompiles preplaced units and start locations from the `CreateAllUnits`, `config`, and `InitCustomPlayerSlots` functions into `war3mapUnits.doo`.
+
+### Changed
+
+- Updated `War3Net.Build.Core` and `War3Net.CodeAnalysis.Jass` from v5.4.0 to v5.4.1.
+
+### Fixed
+
+- The sounds, cameras, and regions decompilers no longer fail when the function body contains comments or blank lines.
+
 ## v5.4.0 - 2022-02-13
+
+### Added
+
+- Initial release, with `JassScriptDecompiler` for regenerating war3map files from a map's JASS script:
+  - `TryDecompileMapTriggers` regenerates `war3map.wtg`, including trigger categories, variables, events, conditions, and actions, `for` and `foreach` loops, if-then-else, and custom script code.
+  - `TryDecompileMapSounds` regenerates `war3map.w3s` from the `InitSounds` function, including music variables.
+  - `TryDecompileMapCameras` regenerates `war3map.w3c`.
+  - `TryDecompileMapRegions` regenerates `war3map.w3r`, including weather effects and ambient sounds.
+  - `TryDecompileMapImportedFiles` regenerates `war3map.imp` from an MPQ archive.
+- Added `TriggerDataContext`, which exposes lookup dictionaries for the types, params, calls, conditions, and actions of a `TriggerData` object.
 
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.3]: https://github.com/Drake53/War3Net/releases/tag/v6.0.3

--- a/docs/changelogs/War3Net.CodeAnalysis.Decompilers.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.Decompilers.changelog.md
@@ -1,0 +1,53 @@
+# War3Net.CodeAnalysis.Decompilers Changelog
+
+All notable changes to the `War3Net.CodeAnalysis.Decompilers` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v6.0.3] - 2026-07-04
+
+## [v6.0.2] - 2026-03-01
+
+## [v6.0.1] - 2026-02-01
+
+## [v6.0.0] - 2026-01-25
+
+## v5.8.2 - 2025-09-27
+
+## [v5.8.1] - 2025-09-12
+
+## [v5.8.0] - 2025-09-06
+
+## v5.7.1 - 2023-01-19
+
+## v5.7.0 - 2023-01-08
+
+## v5.6.1 - 2023-01-07
+
+## v5.6.0 - 2022-12-20
+
+## v5.5.5 - 2022-11-13
+
+## v5.5.3 - 2022-10-29
+
+## v5.5.2 - 2022-10-25
+
+## v5.5.0 - 2022-08-20
+
+## v5.4.5 - 2022-05-27
+
+## v5.4.2 - 2022-02-18
+
+## v5.4.1 - 2022-02-13
+
+## v5.4.0 - 2022-02-13
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.3]: https://github.com/Drake53/War3Net/releases/tag/v6.0.3
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.8.1]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.12
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.CodeAnalysis.Jass.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.Jass.changelog.md
@@ -4,18 +4,25 @@ All notable changes to the `War3Net.CodeAnalysis.Jass` package, newest version f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v6.0.2 - 2026-03-01
+## [Unreleased]
+
+## [v6.0.2] - 2026-03-01
 
 ### Breaking Changes
 
 - Updated target framework from .NET 5.0 to .NET 6.0.
 
-## v6.0.1 - 2026-02-01
+## [v6.0.1] - 2026-02-01
 
 _No functional changes; package readme and metadata updated for nuget.org presentation._
 
-## v6.0.0 - 2026-01-25
+## [v6.0.0] - 2026-01-25
 
 ### Breaking Changes
 
 - Breaking changes have been documented in [the migration guide](../guides/jass-migration-guide-v5-to-v6.md).
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25

--- a/docs/changelogs/War3Net.CodeAnalysis.Jass.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.Jass.changelog.md
@@ -26,7 +26,266 @@ _No functional changes; package readme and metadata updated for nuget.org presen
 
 - Breaking changes have been documented in [the migration guide](../guides/jass-migration-guide-v5-to-v6.md).
 
+## [v5.8.0] - 2025-09-06
+
+### Added
+
+- `ExpressionSyntaxExtensions.TryGetIntegerExpressionValue` now also handles `JassHexadecimalLiteralExpressionSyntax`, so hexadecimal literals are recognized when decompiling a script into native editor files (#52).
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis` and `War3Net.Common` from v5.6.1 to v5.8.0.
+
+## v5.6.1 - 2023-01-07
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis` and `War3Net.Common` from v5.6.0 to v5.6.1.
+
+## v5.6.0 - 2022-12-20
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis` and `War3Net.Common` from v5.5.5 to v5.6.0.
+
+## v5.5.5 - 2022-11-13
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis` and `War3Net.Common` from v5.5.3 to v5.5.5.
+
+## v5.5.3 - 2022-10-29
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis` and `War3Net.Common` from v5.5.2 to v5.5.3.
+
+## v5.5.2 - 2022-10-25
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis` and `War3Net.Common` from v5.5.0 to v5.5.2.
+
+## v5.5.0 - 2022-08-20
+
+### Changed
+
+- Shared syntax-tree types moved to the new `War3Net.CodeAnalysis` package, which is now a dependency.
+- Updated `War3Net.Common` from v5.4.5 to v5.5.0.
+
+## v5.4.5 - 2022-05-27
+
+### Breaking Changes
+
+- Renamed `IDeclarationSyntax` to `ITopLevelDeclarationSyntax`.
+
+### Changed
+
+- Optimized the whitespace parser, and stopped parsing trailing whitespace automatically after a keyword.
+- `StatementParser` now uses `Parser.Rec()` instead of `ExpressionParser.Build()`.
+- Updated `War3Net.Common` from v5.4.0 to v5.4.5.
+
+## v5.4.1 - 2022-02-13
+
+### Added
+
+- Added syntax support required by the `war3mapUnits.doo` decompiler.
+
+## v5.4.0 - 2022-02-13
+
+### Breaking Changes
+
+- Merged the separate statement and declaration classes for empty and comment syntax into a single class each.
+- Replaced `ICustomScriptAction` with `IStatementLine`, `IGlobalLine`, and `IDeclarationLine`.
+
+### Added
+
+- Added `JassSyntaxFactory.ConditionFunctionDeclarator`, for functions that return a `boolean`.
+- `TriggerRenderer` now supports Lua triggers.
+
+### Changed
+
+- `OperatorType` conversions now throw when the operator is invalid.
+- Updated `War3Net.Common` from v5.0.2 to v5.4.0.
+
+### Fixed
+
+- Fixed `JassCommentStatementSyntax.Equals(IStatementSyntax)`.
+
+## v5.3.1 - 2022-01-19
+
+### Added
+
+- Added `IInvocationSyntax`.
+- Added `JassReturnStatementSyntax.Empty`.
+- Moved `IExpressionSyntaxExtensions` here from the decompilers project.
+
+### Fixed
+
+- Fixed several syntax classes having an `internal` constructor, making them impossible to construct from outside the assembly.
+- Comment syntax equality now compares the comment text instead of only the node type.
+
+## v5.3.0 - 2022-01-16
+
+### Added
+
+- Added `JassSyntaxFacts` class.
+- Added `JassRenamer`, for renaming declarations in a parsed script.
+- Added `JassSyntaxFactory.ParseFunctionDeclaration`, `TryParse` methods, binary and unary operator parsers, and factory methods for exit statements and parenthesized expressions.
+- All JASS syntax classes now override `ToString()`.
+- `JassRenderer` now supports custom script actions.
+
+### Fixed
+
+- `FourCCLiteralExpressionParser` no longer throws on malformed input.
+- Fixed `JassSyntaxFactory` literal expression inconsistencies compared to `ParseExpression`.
+
+## v5.2.2 - 2021-02-16
+
+### Added
+
+- Added an option to apply the `CSharpLua.Template` attribute to transpiled global declarations.
+
+### Changed
+
+- Updated `War3Net.Common` from v5.0.0 to v5.0.2.
+
+## v5.2.1 - 2021-02-14
+
+### Breaking Changes
+
+- Removed the JASS syntax classes that were marked obsolete in v5.2.0.
+
+### Added
+
+- Added a new `JassRenderer` implementation for the new syntax tree, and more `JassSyntaxFactory` methods.
+
+## v5.2.0 - 2021-01-24
+
+### Breaking Changes
+
+- Replaced the JASS syntax tree, parser, and `JassSyntaxFactory` with a new implementation; the previous classes are marked obsolete.
+
+### Added
+
+- Added new JASS syntax classes and an updated set of keywords and symbols.
+- Added `JassSyntaxFactory` parser methods and syntax factory methods for variables.
+
+## v5.1.0 - 2020-12-22
+
+### Added
+
+- Added nullable reference type annotations to the syntax classes.
+- Added `ToJassTypeKeyword` extension method for `Type`.
+
+### Changed
+
+- Removed the `EmptyNode` properties from the syntax classes.
+- Updated `War3Net.Common` from v0.3.2 to v5.0.0.
+
+### Fixed
+
+- Fixed parsing failing when the file does not end with an empty line.
+- Fixed several `JassRenderer` bugs.
+
+## v5.0.0 - 2020-12-14
+
+### Breaking Changes
+
+- The transpilers have been moved to the new `War3Net.CodeAnalysis.Transpilers` package.
+- Updated target framework from .NET Core 3.1 to .NET 5.0.
+
+### Added
+
+- Added a dependency on `War3Net.Common` (v0.3.2).
+- Added more `JassSyntaxFactory` methods.
+
+## v2.1.0 - 2020-11-12
+
+_No functional changes; version bumped to align with the rest of War3Net's 2020-11-12 release._
+
+## v2.0.1 - 2020-11-11
+
+### Fixed
+
+- Several `JassToLuaTranspiler` bugfixes.
+
+## v2.0.0 - 2020-10-27
+
+### Breaking Changes
+
+- Updated target framework from .NET Standard 2.1 to .NET Core 3.1.
+
+### Added
+
+- Added `JassToLuaTranspiler`, including handling of string concatenation.
+- Added `JassParser` parse method overloads.
+
+### Changed
+
+- Changed several internal methods to public.
+
+## v1.2.2 - 2020-09-14
+
+### Breaking Changes
+
+- Updated target framework from .NET Standard 2.0 to .NET Standard 2.1.
+
+## v1.2.1 - 2020-06-01
+
+### Added
+
+- The JASS API transpiler now generates the `@CSharpLua.Ignore` attribute for classes.
+
+## v1.2.0 - 2020-01-10
+
+### Removed
+
+- Removed the dependency on the `War3Net.CodeAnalysis.Common` package; the attributes it provided are no longer applied by the transpiler.
+
+## v1.1.0 - 2020-01-03
+
+### Changed
+
+- JASS fields and functions are now transpiled using `@CSharpLua.Template` instead of `NativeLuaMemberAttribute`.
+
+### Fixed
+
+- Fixed the renamed `__inherits__` keyword.
+- Fixed exceptions when a function has zero arguments.
+
+## v1.0.3 - 2019-11-20
+
+### Added
+
+- Added more `JassSyntaxFactory` methods.
+
+## v1.0.2 - 2019-10-08
+
+_No functional changes; package metadata updated._
+
+## v1.0.1 - 2019-10-06
+
+### Breaking Changes
+
+- The `JassApi` files (`common.j` and `Blizzard.j`) and the transpiler attributes have been moved out of this package; the attributes now live in `War3Net.CodeAnalysis.Common`.
+
+### Added
+
+- Functions are now automatically transpiled as natives when `NativeLuaMemberAttribute` is applied.
+
+## v1.0.0 - 2019-09-30
+
+### Added
+
+- Initial release, with a tokenizer, parser, syntax tree, and renderer for JASS:
+  - `JassParser` and `JassSyntaxFactory` for parsing JASS source into a syntax tree.
+  - `JassRenderer` and `JassRendererOptions` for rendering a syntax tree back to JASS source.
+  - `JassTranspiler` and `JassTranspilerHelper` for transpiling JASS to C#, including support for the attributes used by the subsequent C#-to-Lua step.
+  - A source code obfuscator for JASS.
+
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
 [v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
 [v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.CodeAnalysis.Jass.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.Jass.changelog.md
@@ -4,17 +4,17 @@ All notable changes to the `War3Net.CodeAnalysis.Jass` package, newest version f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v6.0.2
+## v6.0.2 - 2026-03-01
 
 ### Breaking Changes
 
 - Updated target framework from .NET 5.0 to .NET 6.0.
 
-## v6.0.1
+## v6.0.1 - 2026-02-01
 
 _No functional changes; package readme and metadata updated for nuget.org presentation._
 
-## v6.0.0
+## v6.0.0 - 2026-01-25
 
 ### Breaking Changes
 

--- a/docs/changelogs/War3Net.CodeAnalysis.Jass.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.Jass.changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added .NET 10.0 target framework; the package now targets both .NET 6.0 and .NET 10.0.
+
 ## [v6.0.2] - 2026-03-01
 
 ### Breaking Changes

--- a/docs/changelogs/War3Net.CodeAnalysis.Jass.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.Jass.changelog.md
@@ -1,12 +1,21 @@
 # War3Net.CodeAnalysis.Jass Changelog
 
+All notable changes to the `War3Net.CodeAnalysis.Jass` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## v6.0.2
-### Breaking changes
+
+### Breaking Changes
+
 - Updated target framework from .NET 5.0 to .NET 6.0.
 
 ## v6.0.1
-No functional changes; package readme and metadata updated for nuget.org presentation.
+
+_No functional changes; package readme and metadata updated for nuget.org presentation._
 
 ## v6.0.0
-### Breaking changes
-- Breaking changes have been documented in [the migration guide](../guides/jass-migration-guide-v5-to-v6.md)
+
+### Breaking Changes
+
+- Breaking changes have been documented in [the migration guide](../guides/jass-migration-guide-v5-to-v6.md).

--- a/docs/changelogs/War3Net.CodeAnalysis.Transpilers.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.Transpilers.changelog.md
@@ -6,53 +6,222 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added .NET 10.0 target framework; the package now targets both .NET 6.0 and .NET 10.0.
+
 ## [v6.0.2] - 2026-03-01
+
+### Breaking Changes
+
+- Updated target framework from .NET 5.0 to .NET 6.0.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v6.0.1 to v6.0.2.
+- Updated `War3Net.CSharpLua` from v2.0.2 to v2.0.3.
 
 ## [v6.0.1] - 2026-02-01
 
+_No functional changes; package readme and metadata updated for nuget.org presentation._
+
 ## [v6.0.0] - 2026-01-25
+
+### Breaking Changes
+
+- Both transpilers have been reworked for the new `War3Net.CodeAnalysis.Jass` v6.0.0 syntax tree. Since there is a `Transpile` overload per JASS syntax class, the overload set changed along with the syntax classes described in [the migration guide](../guides/jass-migration-guide-v5-to-v6.md).
+- Most `Transpile` methods on `JassToCSharpTranspiler` gained overloads that take a leading and/or trailing `JassSyntaxTriviaList`, so that a parent node can pass down the trivia of the tokens it discards.
+
+### Added
+
+- The transpiled C# now preserves the whitespace and comments of the JASS source, which are exposed as trivia by the new syntax tree.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.8.0 to v6.0.0.
+- Updated `War3Net.CSharpLua` from v2.0.1 to v2.0.2.
 
 ## [v5.8.0] - 2025-09-06
 
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.6.1 to v5.8.0.
+- Updated `War3Net.CSharpLua` from v1.7.20 to v2.0.1.
+
 ## v5.6.1 - 2023-01-07
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.6.0 to v5.6.1.
+- Updated `War3Net.CSharpLua` from v1.7.19 to v1.7.20.
 
 ## v5.6.0 - 2022-12-20
 
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.5.5 to v5.6.0.
+- Updated `War3Net.CSharpLua` from v1.7.18 to v1.7.19.
+
 ## v5.5.5 - 2022-11-13
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.5.3 to v5.5.5.
 
 ## v5.5.3 - 2022-10-29
 
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.5.2 to v5.5.3.
+
 ## v5.5.2 - 2022-10-25
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.5.0 to v5.5.2.
+- Updated `War3Net.CSharpLua` from v1.7.17 to v1.7.18.
 
 ## v5.5.0 - 2022-08-20
 
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.4.5 to v5.5.0.
+- Updated `War3Net.CSharpLua` from v1.7.16 to v1.7.17.
+
 ## v5.4.5 - 2022-05-27
+
+### Breaking Changes
+
+- `Transpile(IDeclarationSyntax)` now takes an `ITopLevelDeclarationSyntax`, on both `JassToCSharpTranspiler` and `JassToLuaTranspiler`.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.4.1 to v5.4.5.
+- Updated `War3Net.CSharpLua` from v1.7.15 to v1.7.16.
 
 ## v5.4.1 - 2022-02-13
 
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.4.0 to v5.4.1.
+
 ## v5.4.0 - 2022-02-13
+
+### Breaking Changes
+
+- `Transpile(JassCommentDeclarationSyntax)` and `Transpile(JassCommentStatementSyntax)` have been merged into `Transpile(JassCommentSyntax)`, and `Transpile(JassEmptyDeclarationSyntax)` and `Transpile(JassEmptyStatementSyntax)` into `Transpile(JassEmptySyntax)`.
+
+### Added
+
+- Added `PolyglotJassToLuaTranspiler`, which transpiles JASS scripts that contain embedded Lua code delimited by `//! beginusercode` and `//! endusercode`, and renders the result to a `TextWriter`.
+- Added `JassToLuaTranspiler.Transpile(JassFunctionDeclaratorSyntax)`.
+- The package now contains SourceLink metadata.
+
+### Changed
+
+- `JassToLuaTranspiler.Transpile(JassGlobalDeclarationListSyntax)` now throws a `NotSupportedException` for unrecognized global declarations, instead of a `SwitchExpressionException`.
+- Updated `War3Net.CodeAnalysis.Jass` from v5.2.2 to v5.4.0.
+- Updated `War3Net.CSharpLua` from v1.7.13 to v1.7.15.
 
 ## v5.2.8 - 2021-04-08
 
+### Changed
+
+- Updated `War3Net.CSharpLua` from v1.7.12 to v1.7.13.
+
 ## v5.2.7 - 2021-04-06
+
+### Changed
+
+- Updated `War3Net.CSharpLua` from v1.7.8 to v1.7.12.
 
 ## v5.2.6 - 2021-03-06
 
+### Changed
+
+- Updated `War3Net.CSharpLua` from v1.7.7 to v1.7.8.
+
 ## v5.2.5 - 2021-02-21
+
+### Changed
+
+- Updated `War3Net.CSharpLua` from v1.7.5 to v1.7.7.
 
 ## v5.2.3 - 2021-02-20
 
+### Changed
+
+- Updated `War3Net.CSharpLua` from v1.7.4 to v1.7.5.
+
 ## v5.2.2 - 2021-02-16
+
+### Added
+
+- Added `JassToCSharpTranspiler.ApplyCSharpLuaTemplateAttribute`, which emits a `@CSharpLua.Template` documentation comment on transpiled global declarations, and `JassToCSharpTranspiler.JassToLuaTranspiler`, which is the transpiler used to generate the template's Lua identifier.
+- Added `SyntaxNodeExtensions.WithCSharpLuaTemplateAttribute<TSyntax>` in the new `War3Net.CodeAnalysis.Transpilers.Extensions` namespace.
 
 ## v5.2.1 - 2021-02-14
 
+### Breaking Changes
+
+- `JassToCSharpTranspiler` has been reimplemented against the `War3Net.CodeAnalysis.Jass` v5.2.x syntax tree: it is now a non-static class that must be instantiated, and its `Transpile` extension methods have been replaced by instance methods taking the new `Jass*Syntax` classes.
+- Removed `JassTranspiler`, `JassTranspilerHelper`, `CompilationHelper`, `TokenTranspileFlags`, and `TranspileToEnumHandler`. As a result, the JASS-to-C# transpiler no longer wraps its output in a namespace and class declaration, no longer converts `common.j` handle types into C# enums, and no longer offers helpers to compile and emit the transpiled code (`CompileCSharpFromJass`, `PrepareCompilation`, `GetReferencesAndUsingDirectives`, `SerializeTo`).
+- `JassToLuaTranspiler.Transpile(IVariableDeclarator, bool)` now takes an `IVariableDeclaratorSyntax`, following the rename in `War3Net.CodeAnalysis.Jass`.
+
+### Added
+
+- Added `IgnoreComments`, `IgnoreEmptyDeclarations`, `IgnoreEmptyStatements`, and `KeepFunctionsSeparated` options to `JassToLuaTranspiler`.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.2.0 to v5.2.1.
+- Updated `War3Net.CSharpLua` from v1.7.1 to v1.7.4.
+
 ## v5.2.0 - 2021-01-24
+
+### Breaking Changes
+
+- `JassToLuaTranspiler` has been reimplemented against the `War3Net.CodeAnalysis.Jass` v5.2.0 syntax tree: `RegisterJassFile` now takes a `JassCompilationUnitSyntax` instead of a `FileSyntax`, and its `Transpile` methods take the new `Jass*Syntax` classes.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.1.0 to v5.2.0.
 
 ## v5.1.1 - 2020-12-24
 
+### Fixed
+
+- Native function declarations are now registered while transpiling to Lua, and not only by `RegisterJassFile`, so calls to a native declared in a file that was transpiled without being registered first no longer throw a `KeyNotFoundException`.
+
 ## v5.1.0 - 2020-12-22
 
+### Breaking Changes
+
+- `JassToLuaTranspiler` is now a non-static class that must be instantiated, and its `TranspileToLua` extension methods have been replaced by instance `Transpile` methods.
+- Removed the obsolete `StringBuilder`-based `Transpile` extension methods, along with the `TranspileStringConcatenationHandler` class they relied on.
+- The `Transpile` methods of `JassToCSharpTranspiler` now check the syntax node itself instead of the `Empty…Node` counterparts that were removed in `War3Net.CodeAnalysis.Jass` v5.1.0.
+
+### Added
+
+- Added `JassToLuaTranspiler.RegisterJassFile(FileSyntax)`, `RegisterFunctionReturnType(MethodInfo)`, and `RegisterGlobalVariableType(FieldInfo)`, which supply the type information needed to transpile expressions to Lua.
+- Added a package readme.
+
+### Changed
+
+- Updated `War3Net.CodeAnalysis.Jass` from v5.0.0 to v5.1.0.
+
+### Fixed
+
+- The line delimiter at the start of a file is no longer dropped when transpiling to Lua.
+
 ## v5.0.0 - 2020-12-15
+
+### Added
+
+- Initial release. The transpiler code was moved out of the `War3Net.CodeAnalysis.Jass` package into this new package.
+- `JassTranspiler` transpiles a parsed JASS `FileSyntax` into a C# `CompilationUnitSyntax`, wrapped in the given namespace and class, optionally emitting only the API as native function declarations.
+- `JassToCSharpTranspiler` provides `Transpile` extension methods that convert individual JASS syntax nodes into Roslyn syntax nodes, with `TranspileToEnumHandler` and `CommonEnumTypesProvider` converting `common.j` handle types into C# enums.
+- `JassToLuaTranspiler` provides `TranspileToLua` extension methods that convert JASS syntax nodes into `CSharpLua.LuaAst` nodes, with `TranspileStringConcatenationHandler` handling JASS' `+` operator on strings.
 
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1

--- a/docs/changelogs/War3Net.CodeAnalysis.Transpilers.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.Transpilers.changelog.md
@@ -1,0 +1,61 @@
+# War3Net.CodeAnalysis.Transpilers Changelog
+
+All notable changes to the `War3Net.CodeAnalysis.Transpilers` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v6.0.2] - 2026-03-01
+
+## [v6.0.1] - 2026-02-01
+
+## [v6.0.0] - 2026-01-25
+
+## [v5.8.0] - 2025-09-06
+
+## v5.6.1 - 2023-01-07
+
+## v5.6.0 - 2022-12-20
+
+## v5.5.5 - 2022-11-13
+
+## v5.5.3 - 2022-10-29
+
+## v5.5.2 - 2022-10-25
+
+## v5.5.0 - 2022-08-20
+
+## v5.4.5 - 2022-05-27
+
+## v5.4.1 - 2022-02-13
+
+## v5.4.0 - 2022-02-13
+
+## v5.2.8 - 2021-04-08
+
+## v5.2.7 - 2021-04-06
+
+## v5.2.6 - 2021-03-06
+
+## v5.2.5 - 2021-02-21
+
+## v5.2.3 - 2021-02-20
+
+## v5.2.2 - 2021-02-16
+
+## v5.2.1 - 2021-02-14
+
+## v5.2.0 - 2021-01-24
+
+## v5.1.1 - 2020-12-24
+
+## v5.1.0 - 2020-12-22
+
+## v5.0.0 - 2020-12-15
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.CodeAnalysis.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.changelog.md
@@ -60,9 +60,7 @@ _No functional changes; version bumped to align with the rest of War3Net's v5.5.
 
 ## v5.5.2 - 2022-10-25
 
-### Changed
-
-- Sealed the internal `IfThenElseParser` and `UntilWithLeadingParser` classes.
+_No functional changes; version bumped to align with the rest of War3Net's v5.5.2 release._
 
 ## v5.5.0 - 2022-08-20
 

--- a/docs/changelogs/War3Net.CodeAnalysis.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.changelog.md
@@ -1,0 +1,33 @@
+# War3Net.CodeAnalysis Changelog
+
+All notable changes to the `War3Net.CodeAnalysis` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v6.0.2] - 2026-03-01
+
+## [v6.0.1] - 2026-02-01
+
+## [v6.0.0] - 2026-01-25
+
+## [v5.8.0] - 2025-09-06
+
+## v5.6.1 - 2023-01-07
+
+## v5.6.0 - 2022-12-20
+
+## v5.5.5 - 2022-11-13
+
+## v5.5.3 - 2022-10-29
+
+## v5.5.2 - 2022-10-25
+
+## v5.5.0 - 2022-08-20
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.CodeAnalysis.changelog.md
+++ b/docs/changelogs/War3Net.CodeAnalysis.changelog.md
@@ -6,25 +6,69 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added .NET 10.0 target framework; the package now targets both .NET 6.0 and .NET 10.0.
+
 ## [v6.0.2] - 2026-03-01
+
+### Breaking Changes
+
+- Updated target framework from .NET 5.0 to .NET 6.0.
 
 ## [v6.0.1] - 2026-02-01
 
+_No functional changes; package readme and metadata updated for nuget.org presentation._
+
 ## [v6.0.0] - 2026-01-25
+
+### Added
+
+- Added `IndentedTextWriter`, a `TextWriter` that writes indentation at the start of each line, with `Indent`/`Unindent` methods, a settable `IndentLevel`, a configurable indent string, and a `New(IndentedTextWriter)` method to create a new writer that copies the indent and newline strings of an existing one.
+- Added `SeparatedSyntaxList.Create(TItem)` method, for creating a list with a single item and no separators.
+- Added `SeparatedSyntaxList.CreateBuilder(TItem, int)` overload, to set the builder's initial capacity. It throws `ArgumentOutOfRangeException` when the capacity is less than 1.
+- Added `SeparatedSyntaxList.IsEmpty` property.
+
+### Changed
+
+- `SeparatedSyntaxList.Create(ImmutableArray<TItem>, ImmutableArray<TSeparator>)` now returns the cached `Empty` instance instead of allocating a new list when `items` is empty.
+
+### Fixed
+
+- The `SeparatedList` parser no longer succeeds with an empty result when the item parser fails after consuming input; it now fails instead.
+- The `IfThenElse`, `SeparatedList`, and `UntilWithLeading` parsers now dispose their pooled expected-token lists before throwing `InvalidOperationException` for a parser that consumed no input, so those pooled buffers are no longer leaked.
 
 ## [v5.8.0] - 2025-09-06
 
+_No functional changes; version bumped to align with the rest of War3Net's v5.8.0 release._
+
 ## v5.6.1 - 2023-01-07
+
+_No functional changes; version bumped to align with the rest of War3Net's v5.6.1 release._
 
 ## v5.6.0 - 2022-12-20
 
+_No functional changes; version bumped to align with the rest of War3Net's v5.6.0 release._
+
 ## v5.5.5 - 2022-11-13
+
+_No functional changes; version bumped to align with the rest of War3Net's v5.5.5 release._
 
 ## v5.5.3 - 2022-10-29
 
+_No functional changes; version bumped to align with the rest of War3Net's v5.5.3 release._
+
 ## v5.5.2 - 2022-10-25
 
+### Changed
+
+- Sealed the internal `IfThenElseParser` and `UntilWithLeadingParser` classes.
+
 ## v5.5.0 - 2022-08-20
+
+### Added
+
+- Initial release, with the `ParserExtensions` methods `IfThenElse`, `SeparatedList`, and `UntilWithLeading` for [Pidgin](https://github.com/benjamin-hodgson/Pidgin) parsers, and the `SeparatedSyntaxList<TItem, TSeparator>` type (with its `Builder`) to represent the result of a `SeparatedList` parser.
 
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1

--- a/docs/changelogs/War3Net.Common.changelog.md
+++ b/docs/changelogs/War3Net.Common.changelog.md
@@ -6,51 +6,209 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added .NET 10.0 target framework; the package now targets both .NET 6.0 and .NET 10.0.
+
 ## [v6.0.2] - 2026-03-01
+
+### Breaking Changes
+
+- Updated target framework from .NET 5.0 to .NET 6.0.
 
 ## [v6.0.1] - 2026-02-01
 
+_No functional changes; package readme and metadata updated for nuget.org presentation._
+
 ## [v6.0.0] - 2026-01-25
+
+### Added
+
+- Added `FromByteRaw`, `FromSByteRaw`, `FromInt16Raw`, `FromUInt16Raw`, `FromInt32Raw`, `FromUInt32Raw`, `FromInt64Raw`, and `FromUInt64Raw` methods to `EnumConvert<TEnum>`, which skip the validation performed by their non-`Raw` counterparts.
+- Added `JsonElementExtensions.GetByteRaw<TEnum>` and `JsonElementExtensions.GetInt32Raw<TEnum>`, both with and without a `propertyName` parameter.
 
 ## [v5.8.0] - 2025-09-06
 
+_No functional changes; version bumped to align with the rest of War3Net's v5.8.0 release._
+
 ## v5.6.1 - 2023-01-07
+
+### Added
+
+- Added `EnumerateObject`, `GetBoolean`, and `GetUInt32` extension methods to `JsonElementExtensions`.
 
 ## v5.6.0 - 2022-12-20
 
+### Added
+
+- Added `JsonElementExtensions` class, with `GetByte<TEnum>` and `GetInt32<TEnum>` methods that read an enum from either a JSON number or string, and `propertyName` overloads for `EnumerateArray`, `GetArrayLength`, `GetByte`, `GetInt32`, `GetSingle`, and `GetString`.
+
 ## v5.5.5 - 2022-11-13
+
+### Breaking Changes
+
+- Removed `EnumConvert<TEnum>.FromChar` and `BinaryReaderExtensions.ReadChar<TEnum>`.
+
+### Added
+
+- Added `EnumConvert<TEnum>.FromInt64` and `EnumConvert<TEnum>.FromUInt64`.
+
+### Changed
+
+- `EnumConvert<TEnum>` now uses `Unsafe.As` instead of boxing, and throws a descriptive `InvalidOperationException` instead of an `InvalidCastException` when the underlying type of `TEnum` does not match the method that was called (e.g. `FromInt32` on an enum with `byte` as its underlying type).
+
+### Fixed
+
+- `EnumExtensions.IsDefined` no longer throws an `InvalidCastException` for enums that don't use `int` as their underlying type.
+- Fixed the binary representation of the value in the exception message thrown by `EnumConvert<TEnum>.FromSByte`, `FromUInt16`, and `FromUInt32` for flags enums.
 
 ## v5.5.3 - 2022-10-29
 
+### Fixed
+
+- Fixed `EnumConvert<TEnum>.FromChar` throwing an `InvalidCastException`.
+
 ## v5.5.2 - 2022-10-25
+
+### Breaking Changes
+
+- `DictionaryExtensions.SetValue` now extends `IDictionary<TKey, TValue>` instead of `Dictionary<TKey, TValue>`.
+
+### Added
+
+- Added `EnumConvert<TEnum>` class, with `FromByte`, `FromSByte`, `FromInt16`, `FromUInt16`, `FromInt32`, `FromUInt32`, and `FromChar` methods that convert a primitive value to an enum, validating that the result is defined for `TEnum`.
+- Added `UTF8EncodingProvider` class, which provides `UTF8` and `StrictUTF8` encodings that do not use a byte order mark.
+- Added `StreamExtensions.Copy`, which reads up to a maximum amount of bytes into a new `byte[]`, and a `StreamExtensions.CopyTo` overload that copies into an existing `byte[]`.
+
+### Changed
+
+- The generic `BinaryReaderExtensions` methods (`ReadByte<TEnum>`, `ReadChar<TEnum>`, and `ReadInt32<TEnum>`) now use `EnumConvert<TEnum>`, and throw an `ArgumentException` instead of an `InvalidDataException` for undefined values.
+- Updated `System.Drawing.Common` from v5.0.0 to v6.0.0.
 
 ## v5.5.0 - 2022-08-20
 
+_No functional changes; version bumped to align with the rest of War3Net's v5.5.0 release._
+
 ## v5.4.5 - 2022-05-27
+
+### Changed
+
+- Undefined values of flags enums are now displayed as a binary literal (e.g. `0b00000000000000000000000000000101`) in the exception message thrown by the generic `BinaryReaderExtensions` methods.
 
 ## v5.4.0 - 2022-02-13
 
+### Added
+
+- Added `BinaryReaderExtensions.ReadColorBgra` and `ColorExtensions.ToBgra`.
+
 ## v5.0.2 - 2021-02-14
+
+### Added
+
+- Added `Int32Extensions.ToBool`.
+
+### Changed
+
+- `BinaryReaderExtensions.ReadBool` now throws an `ArgumentException` instead of an `InvalidDataException` when the value read is neither 0 nor 1.
+- `DictionaryExtensions.SetValue` now has a `notnull` constraint on `TKey`.
 
 ## v5.0.1 - 2020-12-25
 
+### Added
+
+- Added `EnumExtensions` class with an `IsDefined<TEnum>` method, which (unlike `Enum.IsDefined`) also accepts combinations of defined flags for enums with `FlagsAttribute`, with an optional `allowNoFlags` parameter to control whether zero is considered valid.
+
+### Changed
+
+- The generic `BinaryReaderExtensions` methods now use `IsDefined<TEnum>`, and no longer throw a `NotSupportedException` for enums whose name ends with "Version"; an `InvalidDataException` is thrown instead.
+
 ## v5.0.0 - 2020-12-14
+
+### Breaking Changes
+
+- Updated target framework from .NET Core 3.1 to .NET 5.0.
+
+### Added
+
+- Added `BinaryReaderExtensions.ReadInt24`, `ReadUInt24`, and `ReadByte<TEnum>`.
+- Added `BinaryWriterExtensions.WriteInt24` and `WriteUInt24`.
+- Added `ColorExtensions` class with a `ToRgba` method.
+- Added `Int32Extensions.ToRgbaColor`.
+
+### Changed
+
+- Updated `System.Drawing.Common` from v4.5.1 to v5.0.0.
 
 ## v0.3.2 - 2020-11-11
 
+_No functional changes._
+
 ## v0.3.1 - 2020-10-29
+
+### Added
+
+- Added optional `endWithNullChar` parameter to `BinaryWriterExtensions.WriteString`, which should be set to `false` when writing a length-prefixed string.
+
+### Fixed
+
+- `WriteString` no longer throws an `ArgumentException` when the string ends with more than one null character.
 
 ## v0.3.0 - 2020-10-27
 
+### Breaking Changes
+
+- Updated target framework from .NET Standard 2.1 to .NET Core 3.1.
+
+### Added
+
+- Added `BinaryReaderExtensions.ReadBool` and `BinaryWriterExtensions.WriteBool`, for reading and writing four-byte booleans.
+- Added `BinaryReaderExtensions.ReadInt32<TEnum>` and `ReadChar<TEnum>`, which validate that the value read is defined for `TEnum`. Values that are a combination of defined flags are accepted for enums with `FlagsAttribute`, and a `NotSupportedException` is thrown for enums whose name ends with "Version".
+
 ## v0.2.0 - 2020-09-14
+
+### Breaking Changes
+
+- Updated target frameworks from .NET Framework 4.5/.NET Standard 1.3/.NET Standard 2.0 to .NET Standard 2.1.
+
+### Changed
+
+- `BinaryReaderExtensions.ReadColorRgba` and the `System.Drawing.Common` dependency are no longer conditional on the target framework.
 
 ## v0.1.3 - 2020-06-21
 
+### Added
+
+- Added `BinaryReaderExtensions.ReadString`, which reads a fixed amount of characters and trims trailing null characters.
+- Added `BinaryWriterExtensions.WriteString` overload that writes a string padded with null characters to a fixed length, and throws an `ArgumentOutOfRangeException` if the string is longer than that length.
+
+### Changed
+
+- `ReadChars` now throws an `InvalidDataException` when the end of the stream is reached without encountering a null character, and an `ArgumentNullException` when the reader is `null`.
+- `WriteString` now throws an `ArgumentException` when the string contains a null character that is not the last character, or an invalid or incomplete surrogate pair, and an `ArgumentNullException` when the writer is `null`.
+- The `s` parameter of `WriteString` is now nullable.
+
+### Fixed
+
+- `BinaryReaderExtensions.ReadChars` now decodes the bytes as UTF-8 instead of reading `char` values one by one, fixing incorrect results for strings containing surrogate characters.
+- `BinaryWriterExtensions.WriteString` now writes surrogate pairs correctly.
+
 ## v0.1.2 - 2020-04-25
+
+### Added
+
+- Added `DictionaryExtensions` class with a `SetValue` method, which adds the key/value pair, or overwrites the value if the key is already present.
 
 ## v0.1.1 - 2020-04-12
 
+### Added
+
+- Added `Int32Extensions` class with a `ToRawcode` method, and `StringExtensions` class with a `FromRawcode` method, for converting between four-character rawcodes and 32-bit integers.
+
 ## v0.1.0 - 2019-12-26
+
+### Added
+
+- Initial release, with `BinaryReaderExtensions` (`ReadChars`, `ReadColorRgba`), `BinaryWriterExtensions` (`WriteString`), and `StreamExtensions` (`CopyTo`, `ReadWord`, `ReadWordAsInt`).
 
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1

--- a/docs/changelogs/War3Net.Common.changelog.md
+++ b/docs/changelogs/War3Net.Common.changelog.md
@@ -1,0 +1,59 @@
+# War3Net.Common Changelog
+
+All notable changes to the `War3Net.Common` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v6.0.2] - 2026-03-01
+
+## [v6.0.1] - 2026-02-01
+
+## [v6.0.0] - 2026-01-25
+
+## [v5.8.0] - 2025-09-06
+
+## v5.6.1 - 2023-01-07
+
+## v5.6.0 - 2022-12-20
+
+## v5.5.5 - 2022-11-13
+
+## v5.5.3 - 2022-10-29
+
+## v5.5.2 - 2022-10-25
+
+## v5.5.0 - 2022-08-20
+
+## v5.4.5 - 2022-05-27
+
+## v5.4.0 - 2022-02-13
+
+## v5.0.2 - 2021-02-14
+
+## v5.0.1 - 2020-12-25
+
+## v5.0.0 - 2020-12-14
+
+## v0.3.2 - 2020-11-11
+
+## v0.3.1 - 2020-10-29
+
+## v0.3.0 - 2020-10-27
+
+## v0.2.0 - 2020-09-14
+
+## v0.1.3 - 2020-06-21
+
+## v0.1.2 - 2020-04-25
+
+## v0.1.1 - 2020-04-12
+
+## v0.1.0 - 2019-12-26
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.Drawing.Blp.changelog.md
+++ b/docs/changelogs/War3Net.Drawing.Blp.changelog.md
@@ -1,0 +1,52 @@
+# War3Net.Drawing.Blp Changelog
+
+All notable changes to the `War3Net.Drawing.Blp` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v6.0.2] - 2026-03-01
+
+## [v6.0.1] - 2026-02-01
+
+## [v6.0.0] - 2026-01-25
+
+## [v5.9.0] - 2025-10-30
+
+## [v5.8.0] - 2025-09-06
+
+## v5.6.1 - 2023-01-07
+
+## v5.6.0 - 2022-12-20
+
+## v5.5.5 - 2022-11-13
+
+## v5.5.3 - 2022-10-29
+
+## v5.5.2 - 2022-10-25
+
+## v5.5.0 - 2022-08-20
+
+## v5.4.5 - 2022-05-27
+
+## v5.4.1 - 2022-04-08
+
+## v5.4.0 - 2022-02-13
+
+## v5.0.0 - 2020-12-14
+
+## v2.0.1 - 2020-10-27
+
+## v2.0.0 - 2020-09-14
+
+## v1.1.0 - 2019-07-09
+
+## v1.0.0 - 2019-07-08
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.9.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.10.30
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.Drawing.Blp.changelog.md
+++ b/docs/changelogs/War3Net.Drawing.Blp.changelog.md
@@ -6,43 +6,162 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added .NET 10.0 target frameworks; the package now targets `net6.0`, `net6.0-windows`, `net10.0`, and `net10.0-windows`.
+
 ## [v6.0.2] - 2026-03-01
+
+### Breaking Changes
+
+- Updated target frameworks from .NET 5.0 to .NET 6.0 (`net5.0`/`net5.0-windows` to `net6.0`/`net6.0-windows`).
+
+### Changed
+
+- Updated `War3Net.Common` from v6.0.1 to v6.0.2.
 
 ## [v6.0.1] - 2026-02-01
 
+_No functional changes; package readme and metadata updated for nuget.org presentation._
+
 ## [v6.0.0] - 2026-01-25
+
+_No functional changes; version bumped to align with the rest of War3Net's v6.0.0 release._
 
 ## [v5.9.0] - 2025-10-30
 
+### Added
+
+- Added `BlpEncoder`, which writes BLP1 files with JPEG compression from BGRA pixel data, including automatic mipmap generation.
+- Added `Blp1EncodingOptions`, to configure whether mipmaps are generated, the number of mipmap levels, the JPEG quality, and the extra flags field.
+
+### Changed
+
+- `JpegLibrary` is now referenced on the `-windows` target frameworks as well, so the encoder is available on every target framework.
+
 ## [v5.8.0] - 2025-09-06
+
+### Changed
+
+- Updated `War3Net.Common` from v5.6.1 to v5.8.0.
 
 ## v5.6.1 - 2023-01-07
 
+### Changed
+
+- Updated `War3Net.Common` from v5.6.0 to v5.6.1.
+
 ## v5.6.0 - 2022-12-20
+
+### Changed
+
+- Updated `War3Net.Common` from v5.5.5 to v5.6.0.
 
 ## v5.5.5 - 2022-11-13
 
+### Changed
+
+- Updated `War3Net.Common` from v5.5.3 to v5.5.5.
+
 ## v5.5.3 - 2022-10-29
+
+### Changed
+
+- Updated `War3Net.Common` from v5.5.2 to v5.5.3.
 
 ## v5.5.2 - 2022-10-25
 
+### Changed
+
+- Sealed the internal `JpegBlockOutputWriter8Bit` class.
+- Updated `War3Net.Common` from v5.5.0 to v5.5.2.
+
 ## v5.5.0 - 2022-08-20
+
+### Changed
+
+- Updated `War3Net.Common` from v5.4.5 to v5.5.0.
 
 ## v5.4.5 - 2022-05-27
 
+### Changed
+
+- Updated `War3Net.Common` from v5.4.0 to v5.4.5.
+
 ## v5.4.1 - 2022-04-08
+
+### Fixed
+
+- Fixed `GetPixels` returning the wrong channel order for palettized BLPs: the colour palette is already read in BGRA order, but the result was swapped anyway when `bgra` was `true`, and left untouched when it was `false`. The decoder now reports the channel order of the decoded data, and the swap only happens when it doesn't match the requested order.
+- Fixed `GetBitmapSource` producing incorrect colours for BLPs with `Direct` content: palettized images had their red and blue channels swapped, and images with colour encoding 3 were created with the 24bpp `Rgb24` format while the pixel data is 32bpp. Both now decode to BGRA and use `Bgra32`.
+- Fixed `GetBitmapSource` for BLP-JPEG images using the pixel format reported by the JPEG decoder, which does not match the (non-standard) channel layout used by BLP1. The format is now chosen from the number of bytes per pixel: `Bgr24` for 3, `Bgra32` otherwise.
 
 ## v5.4.0 - 2022-02-13
 
+### Added
+
+- Added the `net5.0` target framework alongside `net5.0-windows`. On the non-Windows target, BLP-JPEG images are decoded with `JpegLibrary` instead of WPF, which is a new package dependency for that target framework.
+
+### Changed
+
+- `GetBitmapSource` is only available on the `net5.0-windows` target framework.
+- Updated `War3Net.Common` from v5.0.0 to v5.4.0.
+
 ## v5.0.0 - 2020-12-14
+
+### Breaking Changes
+
+- Updated target framework from .NET Core 3.1 to .NET 5.0 (`net5.0-windows`).
+
+### Changed
+
+- Updated `War3Net.Common` from v0.3.0 to v5.0.0.
 
 ## v2.0.1 - 2020-10-27
 
+### Breaking Changes
+
+- The underlying type of the public `FileFormatVersion` enum changed from `uint` to `int`.
+
+### Changed
+
+- Header parsing now uses the `BinaryReader` extension methods from `War3Net.Common`, which is a new package dependency.
+- An unrecognized file format version now throws `NotSupportedException`, and an unrecognized content type now throws `InvalidDataException`, instead of a plain `Exception`.
+
 ## v2.0.0 - 2020-09-14
+
+### Breaking Changes
+
+- Updated target frameworks from .NET Framework 4.6/.NET Standard 1.3/.NET Standard 2.0 to .NET Core 3.1. The package now always uses WPF, and is Windows-only.
+- Removed `GetSKBitmap`, and with it the `SkiaSharp` dependency.
+- Removed `GetBitmap`, and with it the `System.Drawing.Common` dependency.
+
+### Added
+
+- Added `Width` and `Height` properties.
+- `GetPixels` now supports BLPs with JPEG content, by decoding them through `GetBitmapSource`. Previously it read the JPEG data as if it were palettized, and was documented as unsupported for that content type.
+- `FileFormatVersion` is now public.
+
+### Changed
+
+- Opening a BLP-JPEG whose alpha depth is not 0 or 8 no longer throws `NotSupportedException`.
 
 ## v1.1.0 - 2019-07-09
 
+### Added
+
+- Implemented `Direct` (palettized and DXT compressed) content support in `GetSKBitmap` and `GetBitmapSource`; both previously threw `NotImplementedException` for that content type.
+- The `mipMapLevel` parameter of `GetSKBitmap`, `GetBitmap`, and `GetBitmapSource` now defaults to `0`.
+
+### Fixed
+
+- Fixed `GetBitmapSource` returning inverted colours for BLP-JPEG images: it returned the decoded JPEG frame as-is, without inverting the channel values as BLP1 requires.
+
 ## v1.0.0 - 2019-07-08
+
+### Added
+
+- Initial release, based on [SereniaBLPLib](https://github.com/WoW-Tools/SereniaBLPLib). `BlpFile` reads BLP1 and BLP2 images (BLP0 is not supported) with JPEG, palettized, and DXT1/DXT3/DXT5 compressed content, and exposes `MipMapCount`, `GetPixels`, `GetSKBitmap`, `GetBitmap` (not available on .NET Standard 1.3), and `GetBitmapSource` (.NET Framework 4.6 only).
 
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1

--- a/docs/changelogs/War3Net.Drawing.Blp.changelog.md
+++ b/docs/changelogs/War3Net.Drawing.Blp.changelog.md
@@ -73,7 +73,6 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 ### Changed
 
-- Sealed the internal `JpegBlockOutputWriter8Bit` class.
 - Updated `War3Net.Common` from v5.5.0 to v5.5.2.
 
 ## v5.5.0 - 2022-08-20

--- a/docs/changelogs/War3Net.IO.Compression.changelog.md
+++ b/docs/changelogs/War3Net.IO.Compression.changelog.md
@@ -6,43 +6,177 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added .NET 10.0 target framework; the package now targets both .NET 6.0 and .NET 10.0.
+
 ## [v6.0.2] - 2026-03-01
+
+### Breaking Changes
+
+- The `compressionLevel` parameter of `ZLibCompression.Compress` changed from `Ionic.Zlib.CompressionLevel` to `System.IO.Compression.CompressionLevel`.
+- Updated target framework from .NET 5.0 to .NET 6.0.
+
+### Added
+
+- Added `Crc32Checksum` class with a `Compute(Stream)` method, backed by `System.IO.Hashing`.
+
+### Changed
+
+- The default compression level used by `ZLibCompression.Compress(Stream, int, bool)` changed from `BestCompression` to `Optimal`.
+- Updated `War3Net.Common` from v6.0.1 to v6.0.2.
+
+### Security
+
+- Replaced the vulnerable `DotNetZip` dependency: ZLib compression/decompression now uses `System.IO.Compression.ZLibStream`, and BZip2 decompression uses `SharpZipLib` again.
 
 ## [v6.0.1] - 2026-02-01
 
+_No functional changes; package readme and metadata updated for nuget.org presentation._
+
 ## [v6.0.0] - 2026-01-25
+
+_No functional changes; version bumped to align with the rest of War3Net's v6.0.0 release._
 
 ## [v5.8.0] - 2025-09-06
 
+### Added
+
+- Added `ZLibCompression.Compress(Stream, int, CompressionLevel, bool)` overload, to control the compression level (the existing overload keeps using `BestCompression`).
+
+### Changed
+
+- Renamed the `bytes` parameter of `ZLibCompression.Compress` to `bytesToCompress`.
+- Updated `War3Net.Common` from v5.6.1 to v5.8.0.
+
 ## v5.6.1 - 2023-01-07
+
+### Changed
+
+- Updated `War3Net.Common` from v5.6.0 to v5.6.1.
 
 ## v5.6.0 - 2022-12-20
 
+### Changed
+
+- Updated `War3Net.Common` from v5.5.5 to v5.6.0.
+
 ## v5.5.5 - 2022-11-13
+
+### Changed
+
+- Updated `War3Net.Common` from v5.5.3 to v5.5.5.
 
 ## v5.5.3 - 2022-10-29
 
+### Changed
+
+- Updated `War3Net.Common` from v5.5.2 to v5.5.3.
+
 ## v5.5.2 - 2022-10-25
+
+### Added
+
+- Added optional `throwOnLessBytesThanExpected` parameter to both `ZLibCompression.Decompress` overloads.
+
+### Changed
+
+- `ZLibCompression.Decompress` now throws an `ArgumentException` when the decompressed data is shorter than `expectedLength`, instead of silently returning a zero-padded array. Pass `throwOnLessBytesThanExpected: false` to get an array resized to the number of bytes actually read.
+- Sealed the internal `LinkedNode` class.
+- Updated `War3Net.Common` from v5.5.0 to v5.5.2.
 
 ## v5.5.0 - 2022-08-20
 
+### Changed
+
+- Updated `DotNetZip` from v1.15.0 to v1.16.0, to fix a package version conflict.
+- Updated `War3Net.Common` from v5.4.5 to v5.5.0.
+
 ## v5.4.5 - 2022-05-27
+
+### Changed
+
+- Updated `War3Net.Common` from v5.4.0 to v5.4.5.
 
 ## v5.4.0 - 2022-02-13
 
+### Changed
+
+- Updated `War3Net.Common` from v5.0.2 to v5.4.0.
+
 ## v5.1.0 - 2021-02-14
+
+### Changed
+
+- `BZip2Compression.Decompress` now uses `DotNetZip` instead of `SharpZipLib`, removing the `SharpZipLib` dependency.
+- Updated `War3Net.Common` from v5.0.1 to v5.0.2.
 
 ## v5.0.1 - 2020-12-25
 
+### Changed
+
+- Removed obsolete `NETCOREAPP3_0` conditional compilation from `LinkedNode`.
+- Updated `War3Net.Common` from v5.0.0 to v5.0.1.
+
 ## v5.0.0 - 2020-12-14
+
+### Breaking Changes
+
+- Updated target framework from .NET Core 3.1 to .NET 5.0.
+
+### Changed
+
+- Updated `DotNetZip` from v1.13.8 to v1.15.0 and `SharpZipLib` from v1.2.0 to v1.3.1.
+- Updated `War3Net.Common` from v0.3.2 to v5.0.0.
 
 ## v1.0.2 - 2020-11-11
 
+### Changed
+
+- Updated `War3Net.Common` from v0.3.0 to v0.3.2.
+
 ## v1.0.1 - 2020-10-27
+
+### Breaking Changes
+
+- Updated target framework from .NET Standard 2.1 to .NET Core 3.1.
+
+### Changed
+
+- Updated `War3Net.Common` from v0.2.0 to v0.3.0.
 
 ## v1.0.0 - 2020-09-14
 
+### Breaking Changes
+
+- Updated target frameworks from .NET Framework 4.5/.NET Standard 2.0 to .NET Standard 2.1.
+- Renamed the compression classes: `MpqHuffman` to `HuffmanCoding`, `MpqWavCompression` to `AdpcmCompression`, `Deflate` to `ZLibCompression`, and `PKLibDecompress` to `PKLibCompression`.
+- `PKLibCompression` is now a static class; its instance API (constructor plus `Explode`) has been replaced by `Decompress`.
+- `Deflate.TryCompress` has been replaced by `ZLibCompression.Compress`, which returns a `Stream` containing the compressed data instead of writing to a caller-supplied stream and returning the compressed size.
+- `HuffmanCoding.Decompress` now returns `byte[]` instead of `MemoryStream`.
+- The `expectedLength` parameters changed from `int` to `uint`.
+- Removed the `CompressionType` enum; it moved to `War3Net.IO.Mpq` as `MpqCompressionType`.
+- Removed the `StreamExtensions` class; it moved to `War3Net.Common`, which is now a package dependency.
+
+### Added
+
+- Added `BZip2Compression` class, for decompressing BZip2 compressed data.
+- Added `byte[]` overloads of `Decompress` alongside the existing `Stream` overloads on every compression class.
+- `BitStream` is now public, implements `IDisposable`, and gained a constructor with a `leaveOpen` parameter.
+
+### Changed
+
+- Updated `DotNetZip` from v1.13.4 to v1.13.8.
+
+### Fixed
+
+- Fixed PKLib decompression producing incorrect results: the `_sPosition1`/`_sPosition2` decode tables were generated from static fields that had not been initialized yet, and are now built in a static constructor.
+
 ## v0.1.0 - 2019-10-15
+
+### Added
+
+- Initial release, with `Deflate` (ZLib compression and decompression), `PKLibDecompress`, `MpqHuffman`, and `MpqWavCompression` (IMA ADPCM) for the compression methods used in MPQ archives, plus the `CompressionType` enum.
 
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1

--- a/docs/changelogs/War3Net.IO.Compression.changelog.md
+++ b/docs/changelogs/War3Net.IO.Compression.changelog.md
@@ -1,0 +1,51 @@
+# War3Net.IO.Compression Changelog
+
+All notable changes to the `War3Net.IO.Compression` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v6.0.2] - 2026-03-01
+
+## [v6.0.1] - 2026-02-01
+
+## [v6.0.0] - 2026-01-25
+
+## [v5.8.0] - 2025-09-06
+
+## v5.6.1 - 2023-01-07
+
+## v5.6.0 - 2022-12-20
+
+## v5.5.5 - 2022-11-13
+
+## v5.5.3 - 2022-10-29
+
+## v5.5.2 - 2022-10-25
+
+## v5.5.0 - 2022-08-20
+
+## v5.4.5 - 2022-05-27
+
+## v5.4.0 - 2022-02-13
+
+## v5.1.0 - 2021-02-14
+
+## v5.0.1 - 2020-12-25
+
+## v5.0.0 - 2020-12-14
+
+## v1.0.2 - 2020-11-11
+
+## v1.0.1 - 2020-10-27
+
+## v1.0.0 - 2020-09-14
+
+## v0.1.0 - 2019-10-15
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.IO.Compression.changelog.md
+++ b/docs/changelogs/War3Net.IO.Compression.changelog.md
@@ -82,7 +82,6 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 ### Changed
 
 - `ZLibCompression.Decompress` now throws an `ArgumentException` when the decompressed data is shorter than `expectedLength`, instead of silently returning a zero-padded array. Pass `throwOnLessBytesThanExpected: false` to get an array resized to the number of bytes actually read.
-- Sealed the internal `LinkedNode` class.
 - Updated `War3Net.Common` from v5.5.0 to v5.5.2.
 
 ## v5.5.0 - 2022-08-20
@@ -115,7 +114,6 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 ### Changed
 
-- Removed obsolete `NETCOREAPP3_0` conditional compilation from `LinkedNode`.
 - Updated `War3Net.Common` from v5.0.0 to v5.0.1.
 
 ## v5.0.0 - 2020-12-14

--- a/docs/changelogs/War3Net.IO.Mpq.changelog.md
+++ b/docs/changelogs/War3Net.IO.Mpq.changelog.md
@@ -1,133 +1,220 @@
 # War3Net.IO.Mpq Changelog
 
+All notable changes to the `War3Net.IO.Mpq` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## v6.0.3
-### Changes
+
+### Added
+
 - Added `Count` and `EnumerateHashes()` to `MpqArchive`.
+
+### Changed
+
 - Changed `MpqArchive[int]` from internal to public.
 
 ## v6.0.2
-### Breaking changes
+
+### Breaking Changes
+
 - `Attributes.Crc32s` changed from `List<int>` to `List<uint>`, matching the actual unsigned nature of CRC32 values.
 - Updated target framework from .NET 5.0 to .NET 6.0.
-### Changes
-- Replaced the vulnerable DotNetZip dependency with `System.IO.Compression` and an internal CRC32 implementation.
+
+### Changed
+
+- Replaced the vulnerable `DotNetZip` dependency with `System.IO.Compression` and an internal CRC32 implementation.
 
 ## v6.0.1
-No functional changes; package readme and metadata updated for nuget.org presentation.
+
+_No functional changes; package readme and metadata updated for nuget.org presentation._
 
 ## v6.0.0
-No functional changes; version bumped to align with the rest of War3Net's v6.0.0 release.
+
+_No functional changes; version bumped to align with the rest of War3Net's v6.0.0 release._
 
 ## v5.8.1
-### Bugfixes
+
+### Fixed
+
 - Fixed `MpqStream` not disposing its underlying stream, so `using` statements around an `MpqStream` now properly release the base stream.
 
 ## v5.8.0
-### Changes
+
+### Added
+
 - Added `MpqStreamFactory` class as the entry point for constructing `MpqStream` instances, replacing direct use of internal `MpqStream` constructors.
 - Added `MpqStreamUtils` class with `Compress` and `Encrypt` methods, for compressing/encrypting raw data into the block-and-header layout used by MPQ files independently of building a full archive.
 - Added `IMpqCompressor` interface and `MpqZLibCompressor` implementation, allowing a custom compression algorithm to be plugged into `MpqStreamUtils.Compress`.
 - Added `MpqEncryptionUtils` class, exposing `CalculateEncryptionSeed` publicly.
-### Bugfixes
+
+### Fixed
+
 - Fixed an encrypted single-unit `MpqStream` not being decrypted correctly because the check used the uncompressed size instead of the compressed size.
 - Fixed `MpqFileFlags.BlockOffsetAdjustedKey` handling not being applied correctly in some cases.
 
 ## v5.5.2
-### Changes
+
+### Changed
+
 - Improved parallel read performance by using `MemoryMappedFile` for archive access.
 
 ## v5.5.0
-### Changes
+
+### Changed
+
 - `MpqStream` now uses the `CopyTo` extension method internally.
 - `MpqHeader.Parse` gained an optional `leaveOpen` parameter.
-### Bugfixes
+
+### Fixed
+
 - Fixed a typo affecting behavior in the Mpq read path.
 
 ## v5.4.5
-### Changes
+
+### Changed
+
 - Made the listfile/attributes/signature binary read/write extension methods public.
 - `MpqFile` now checks `MpqStream.CanRead` instead of the removed `MpqStream.CanBeDecrypted`.
 - Moved known `MpqCompressionType` values into a public extension method.
-### Bugfixes
+
+### Fixed
+
 - `MpqStream` with the `SingleUnit` flag no longer buffers data eagerly in its constructor, and now validates `CanRead` and throws on read/seek (instead of in the constructor) when block positions are invalid, avoiding premature exceptions when opening certain archives.
 
 ## v5.2.1
-### Bugfixes
+
+### Fixed
+
 - Fixed incorrect hash table size calculation when creating an archive, which could produce a hash table larger than `MpqTable.MaxSize` or ignore the configured `HashTableSize` (fixes #14).
 
 ## v5.2.0
-### Changes
+
+### Added
+
 - Implemented `MpqArchiveExtensions.VerifySignature`, including an overload that verifies against Blizzard's known public keys automatically.
 - Added support for signing MPQ archives on creation via `MpqArchiveCreateOptions.SignaturePrivateKey`.
 - Added support for the `Unk0x04` attributes flag in `AttributesFlags`/`Attributes`, including verification support in `VerifyAttributes`.
+
+### Changed
+
 - Doubled `MpqTable.MaxSize`.
 
 ## v5.1.3
-### Changes
-- Removed obsolete `FileProvider.FileExists`, `FileProvider.GetFile`, and `FileProvider.EnumerateFiles` methods.
+
+### Changed
+
 - `MpqArchiveBuilder.SaveTo(string, ...)` overloads now use `FileProvider.CreateFileAndFolder` instead of `File.Create`, so parent folders are created automatically.
-### Bugfixes
+
+### Removed
+
+- Removed obsolete `FileProvider.FileExists`, `FileProvider.GetFile`, and `FileProvider.EnumerateFiles` methods.
+
+### Fixed
+
 - Minor nullable-reference and encoding-usage cleanups in `MpqStream`.
 
 ## v5.1.2
-### Changes
+
+### Changed
+
 - `MpqArchiveBuilder` is no longer sealed.
 
 ## v5.1.1
-### Changes
+
+### Changed
+
 - Minor fixes across `BlockTable`, `HashTable`, `MpqArchive`, `MpqArchiveBuilder`, and `MpqArchiveCreateOptions`.
 
 ## v5.1.0
-### Changes
+
+### Changed
+
 - `MpqArchiveBuilder` refactored: constructors and `AddFile`/`RemoveFile`/`SaveTo` methods reworked around the new `MpqArchiveCreateOptions`-based creation API.
-### Bugfixes
+
+### Fixed
+
 - Fixed inconsistent casing across several public members.
 - Fixed encryption seed calculation.
 - Various other minor MPQ fixes (`FileProvider`, `MpqEntry`, `MpqStream`, `StormBuffer`).
 
 ## v5.0.0
-### Breaking changes
+
+### Breaking Changes
+
 - `Attributes` changed from a static extension-method holder to an instantiable sealed class with `Unk`, `Flags`, `Crc32s`, and `DateTimes` properties.
 - Added `AttributesFlags` enum.
 - `MpqArchive` creation now takes an `MpqArchiveCreateOptions` object instead of separate `hashTableSize`/`blockSize`/`writeArchiveFirst` constructor parameters; removed the `DefaultBlockSize` constant.
 - `MpqFile.Name` no longer throws when unset.
-### Changes
-- `MpqFile` now implements `IComparable`, `IComparable<MpqFile>`, and `IEquatable<MpqFile>`, backed by new `MpqFileComparer`, replacing the old `IsSameAs` method.
+
+### Added
+
 - `MpqArchiveBuilder.AddFile` gained an overload accepting explicit `MpqFileFlags`; new `SaveTo` overloads accepting `MpqArchiveCreateOptions`.
 
+### Changed
+
+- `MpqFile` now implements `IComparable`, `IComparable<MpqFile>`, and `IEquatable<MpqFile>`, backed by new `MpqFileComparer`, replacing the old `IsSameAs` method.
+
 ## v1.2.2
-### Changes
-- `MpqFile.MpqStream` property is now public.
+
+### Added
+
 - Added `leaveOpen` parameter to the `MpqArchive` constructor, `MpqArchive.Create`, and `MpqArchiveBuilder.SaveTo`, to control whether the underlying stream is disposed.
 
+### Changed
+
+- `MpqFile.MpqStream` property is now public.
+
 ## v1.2.1
-### Changes
+
+### Added
+
 - Added `MpqArchiveBuilder.RemoveFile(ulong)` overload, alongside the existing `RemoveFile(string)`.
 
 ## v1.2.0
-### Changes
+
+### Added
+
 - Added `MpqArchiveBuilder` class, for incrementally building or modifying an `MpqArchive` (supports adding/removing files and saving to a new archive).
+
+### Changed
+
 - `MpqArchive.HashTableSize` property is now public.
 
 ## v1.1.0
-### Changes
-- Moved `FileProvider` class into the `War3Net.IO.Mpq` namespace.
-- Added `Attributes` class with `VerifyAttributes` extension method, to verify the MPQ "(attributes)" file.
-- Added file-existence and open methods to `MpqFile`.
-### Bugfixes
-- Fixed `MpqFile.OpenRead` to properly close the underlying `MpqStream` after copying its contents.
-### Breaking changes
+
+### Breaking Changes
+
 - `FileProvider.OpenNewWrite` has been renamed to `CreateFileAndFolder`.
 
+### Added
+
+- Added `Attributes` class with `VerifyAttributes` extension method, to verify the MPQ "(attributes)" file.
+- Added file-existence and open methods to `MpqFile`.
+
+### Changed
+
+- Moved `FileProvider` class into the `War3Net.IO.Mpq` namespace.
+
+### Fixed
+
+- Fixed `MpqFile.OpenRead` to properly close the underlying `MpqStream` after copying its contents.
+
 ## v1.0.1
-### Bugfixes
+
+### Fixed
+
 - Various MPQ library bugfixes in `MpqArchive`, `MpqHeader`, and `StormBuffer`.
 
 ## v1.0.0
-### Changes
+
+### Added
+
 - Added `MpqOrphanedFile` class to represent entries in the hash table with no corresponding filename.
 - Added `TryGetHashString` method.
-### Bugfixes
+
+### Fixed
+
 - Fixed "Unable to read beyond the end of the stream" exception in `BlockTable`.
 - Fixed "Unable to determine encryption seed" exception.
 - Fixed "Invalid enum" exception in `MpqArchive`.

--- a/docs/changelogs/War3Net.IO.Mpq.changelog.md
+++ b/docs/changelogs/War3Net.IO.Mpq.changelog.md
@@ -4,7 +4,7 @@ All notable changes to the `War3Net.IO.Mpq` package, newest version first.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v6.0.3
+## v6.0.3 - 2026-07-04
 
 ### Added
 
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Changed `MpqArchive[int]` from internal to public.
 
-## v6.0.2
+## v6.0.2 - 2026-03-01
 
 ### Breaking Changes
 
@@ -25,21 +25,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Replaced the vulnerable `DotNetZip` dependency with `System.IO.Compression` and an internal CRC32 implementation.
 
-## v6.0.1
+## v6.0.1 - 2026-02-01
 
 _No functional changes; package readme and metadata updated for nuget.org presentation._
 
-## v6.0.0
+## v6.0.0 - 2026-01-25
 
 _No functional changes; version bumped to align with the rest of War3Net's v6.0.0 release._
 
-## v5.8.1
+## v5.8.1 - 2025-09-12
 
 ### Fixed
 
 - Fixed `MpqStream` not disposing its underlying stream, so `using` statements around an `MpqStream` now properly release the base stream.
 
-## v5.8.0
+## v5.8.0 - 2025-09-06
 
 ### Added
 
@@ -53,13 +53,13 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 - Fixed an encrypted single-unit `MpqStream` not being decrypted correctly because the check used the uncompressed size instead of the compressed size.
 - Fixed `MpqFileFlags.BlockOffsetAdjustedKey` handling not being applied correctly in some cases.
 
-## v5.5.2
+## v5.5.2 - 2022-10-25
 
 ### Changed
 
 - Improved parallel read performance by using `MemoryMappedFile` for archive access.
 
-## v5.5.0
+## v5.5.0 - 2022-08-20
 
 ### Changed
 
@@ -70,7 +70,7 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 - Fixed a typo affecting behavior in the Mpq read path.
 
-## v5.4.5
+## v5.4.5 - 2022-05-27
 
 ### Changed
 
@@ -82,13 +82,13 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 - `MpqStream` with the `SingleUnit` flag no longer buffers data eagerly in its constructor, and now validates `CanRead` and throws on read/seek (instead of in the constructor) when block positions are invalid, avoiding premature exceptions when opening certain archives.
 
-## v5.2.1
+## v5.2.1 - 2021-07-23
 
 ### Fixed
 
 - Fixed incorrect hash table size calculation when creating an archive, which could produce a hash table larger than `MpqTable.MaxSize` or ignore the configured `HashTableSize` (fixes #14).
 
-## v5.2.0
+## v5.2.0 - 2021-04-27
 
 ### Added
 
@@ -100,7 +100,7 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 - Doubled `MpqTable.MaxSize`.
 
-## v5.1.3
+## v5.1.3 - 2021-02-14
 
 ### Changed
 
@@ -114,19 +114,19 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 - Minor nullable-reference and encoding-usage cleanups in `MpqStream`.
 
-## v5.1.2
+## v5.1.2 - 2021-01-09
 
 ### Changed
 
 - `MpqArchiveBuilder` is no longer sealed.
 
-## v5.1.1
+## v5.1.1 - 2021-01-01
 
 ### Changed
 
 - Minor fixes across `BlockTable`, `HashTable`, `MpqArchive`, `MpqArchiveBuilder`, and `MpqArchiveCreateOptions`.
 
-## v5.1.0
+## v5.1.0 - 2020-12-25
 
 ### Changed
 
@@ -138,7 +138,7 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 - Fixed encryption seed calculation.
 - Various other minor MPQ fixes (`FileProvider`, `MpqEntry`, `MpqStream`, `StormBuffer`).
 
-## v5.0.0
+## v5.0.0 - 2020-12-14
 
 ### Breaking Changes
 
@@ -155,7 +155,7 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 - `MpqFile` now implements `IComparable`, `IComparable<MpqFile>`, and `IEquatable<MpqFile>`, backed by new `MpqFileComparer`, replacing the old `IsSameAs` method.
 
-## v1.2.2
+## v1.2.2 - 2020-11-12
 
 ### Added
 
@@ -165,13 +165,13 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 - `MpqFile.MpqStream` property is now public.
 
-## v1.2.1
+## v1.2.1 - 2020-11-12
 
 ### Added
 
 - Added `MpqArchiveBuilder.RemoveFile(ulong)` overload, alongside the existing `RemoveFile(string)`.
 
-## v1.2.0
+## v1.2.0 - 2020-11-11
 
 ### Added
 
@@ -181,7 +181,7 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 - `MpqArchive.HashTableSize` property is now public.
 
-## v1.1.0
+## v1.1.0 - 2020-09-14
 
 ### Breaking Changes
 
@@ -200,13 +200,13 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 - Fixed `MpqFile.OpenRead` to properly close the underlying `MpqStream` after copying its contents.
 
-## v1.0.1
+## v1.0.1 - 2020-08-10
 
 ### Fixed
 
 - Various MPQ library bugfixes in `MpqArchive`, `MpqHeader`, and `StormBuffer`.
 
-## v1.0.0
+## v1.0.0 - 2020-07-10
 
 ### Added
 

--- a/docs/changelogs/War3Net.IO.Mpq.changelog.md
+++ b/docs/changelogs/War3Net.IO.Mpq.changelog.md
@@ -4,7 +4,9 @@ All notable changes to the `War3Net.IO.Mpq` package, newest version first.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v6.0.3 - 2026-07-04
+## [Unreleased]
+
+## [v6.0.3] - 2026-07-04
 
 ### Added
 
@@ -14,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Changed `MpqArchive[int]` from internal to public.
 
-## v6.0.2 - 2026-03-01
+## [v6.0.2] - 2026-03-01
 
 ### Breaking Changes
 
@@ -25,21 +27,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Replaced the vulnerable `DotNetZip` dependency with `System.IO.Compression` and an internal CRC32 implementation.
 
-## v6.0.1 - 2026-02-01
+## [v6.0.1] - 2026-02-01
 
 _No functional changes; package readme and metadata updated for nuget.org presentation._
 
-## v6.0.0 - 2026-01-25
+## [v6.0.0] - 2026-01-25
 
 _No functional changes; version bumped to align with the rest of War3Net's v6.0.0 release._
 
-## v5.8.1 - 2025-09-12
+## [v5.8.1] - 2025-09-12
 
 ### Fixed
 
 - Fixed `MpqStream` not disposing its underlying stream, so `using` statements around an `MpqStream` now properly release the base stream.
 
-## v5.8.0 - 2025-09-06
+## [v5.8.0] - 2025-09-06
 
 ### Added
 
@@ -223,3 +225,11 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 - `MpqEntry.Filename` is now correctly null if no `MpqHash` references the entry.
 - Orphaned `MpqEntries` no longer use deleted `MpqHashes`.
 - Improved `MpqHeader` exception messages.
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.3]: https://github.com/Drake53/War3Net/releases/tag/v6.0.3
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.8.1]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.12
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.IO.Mpq.changelog.md
+++ b/docs/changelogs/War3Net.IO.Mpq.changelog.md
@@ -58,24 +58,61 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 - Fixed an encrypted single-unit `MpqStream` not being decrypted correctly because the check used the uncompressed size instead of the compressed size.
 - Fixed `MpqFileFlags.BlockOffsetAdjustedKey` handling not being applied correctly in some cases.
 
+## v5.6.1 - 2023-01-07
+
+### Changed
+
+- Updated `War3Net.IO.Compression` from v5.6.0 to v5.6.1.
+
+## v5.6.0 - 2022-12-20
+
+### Changed
+
+- Updated `War3Net.IO.Compression` from v5.5.5 to v5.6.0.
+
+## v5.5.5 - 2022-11-13
+
+### Changed
+
+- Updated `War3Net.IO.Compression` from v5.5.3 to v5.5.5.
+
+## v5.5.3 - 2022-10-29
+
+### Changed
+
+- Updated `War3Net.IO.Compression` from v5.5.2 to v5.5.3.
+
 ## v5.5.2 - 2022-10-25
+
+### Added
+
+- Added `UserData` class, exposing the `"(user data)"` filename constant.
 
 ### Changed
 
 - Improved parallel read performance by using `MemoryMappedFile` for archive access.
+- `MpqHeader.Parse` gained an optional `leaveOpen` parameter.
+- Updated `War3Net.IO.Compression` from v5.5.0 to v5.5.2.
 
 ## v5.5.0 - 2022-08-20
 
 ### Changed
 
-- `MpqStream` now uses the `CopyTo` extension method internally.
-- `MpqHeader.Parse` gained an optional `leaveOpen` parameter.
+- Updated `War3Net.IO.Compression` from v5.4.5 to v5.5.0.
+
+## v5.4.5 - 2022-05-27
+
+### Changed
+
+- Updated `War3Net.IO.Compression` from v5.4.0 to v5.4.5.
 
 ### Fixed
 
-- Fixed a typo affecting behavior in the Mpq read path.
+- The CRC32 of a file is no longer computed when its `MpqStream` cannot be read or seeked, which threw when saving an archive with the `Crc32` attributes flag set.
+- Fixed `MpqFile` comparing `MpqStream.FilePosition` against the relative file offset instead of the absolute one when deciding whether a file's encrypted block offsets need to be recalculated.
+- `MpqStream` is now marked as unreadable when the file is encrypted but no encryption seed could be determined, instead of producing garbage data.
 
-## v5.4.5 - 2022-05-27
+## v5.4.3 - 2022-03-20
 
 ### Changed
 
@@ -86,6 +123,16 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 ### Fixed
 
 - `MpqStream` with the `SingleUnit` flag no longer buffers data eagerly in its constructor, and now validates `CanRead` and throws on read/seek (instead of in the constructor) when block positions are invalid, avoiding premature exceptions when opening certain archives.
+
+## v5.4.0 - 2022-02-13
+
+### Changed
+
+- Updated `War3Net.IO.Compression` from v5.1.0 to v5.4.0.
+
+## v5.3.0 - 2022-01-16
+
+_No functional changes; version bumped to align with the rest of War3Net's v5.3.0 release._
 
 ## v5.2.1 - 2021-07-23
 
@@ -114,10 +161,6 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 ### Removed
 
 - Removed obsolete `FileProvider.FileExists`, `FileProvider.GetFile`, and `FileProvider.EnumerateFiles` methods.
-
-### Fixed
-
-- Minor nullable-reference and encoding-usage cleanups in `MpqStream`.
 
 ## v5.1.2 - 2021-01-09
 
@@ -186,6 +229,16 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 
 - `MpqArchive.HashTableSize` property is now public.
 
+## v1.1.1 - 2020-10-27
+
+### Breaking Changes
+
+- Updated target framework from .NET Standard 2.1 to .NET Core 3.1.
+
+### Changed
+
+- Updated `War3Net.IO.Compression` from v1.0.0 to v1.0.1.
+
 ## v1.1.0 - 2020-09-14
 
 ### Breaking Changes
@@ -228,6 +281,17 @@ _No functional changes; version bumped to align with the rest of War3Net's v6.0.
 - `MpqEntry.Filename` is now correctly null if no `MpqHash` references the entry.
 - Orphaned `MpqEntries` no longer use deleted `MpqHashes`.
 - Improved `MpqHeader` exception messages.
+
+## v0.1.0 - 2019-10-15
+
+### Added
+
+- Initial release, based on Foole's MPQ library (itself based on StormLib), with support for reading and creating MPQ archives:
+  - `MpqArchive` for opening, creating, repairing, and restoring archives, and for replacing individual files.
+  - `MpqFile`, `MpqEntry`, `MpqHash`, and `MpqStream` for working with the files inside an archive, including compression and encryption.
+  - `MpqHeader`, `HashTable`, `BlockTable`, and `ListFile` for the archive's internal structures.
+  - `MpqLocale`, `MpqLocaleProvider`, and `MpqFileFlags` for file metadata.
+  - `MpqParserException`, thrown when an archive cannot be parsed.
 
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.3]: https://github.com/Drake53/War3Net/releases/tag/v6.0.3

--- a/docs/changelogs/War3Net.IO.Mpq.changelog.md
+++ b/docs/changelogs/War3Net.IO.Mpq.changelog.md
@@ -6,11 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+_No unreleased changes._
+
 ## [v6.0.3] - 2026-07-04
 
 ### Added
 
 - Added `Count` and `EnumerateHashes()` to `MpqArchive`.
+- Added .NET 10.0 target framework; the package now targets both .NET 6.0 and .NET 10.0.
 
 ### Changed
 
@@ -23,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `Attributes.Crc32s` changed from `List<int>` to `List<uint>`, matching the actual unsigned nature of CRC32 values.
 - Updated target framework from .NET 5.0 to .NET 6.0.
 
-### Changed
+### Security
 
 - Replaced the vulnerable `DotNetZip` dependency with `System.IO.Compression` and an internal CRC32 implementation.
 

--- a/docs/changelogs/War3Net.IO.Slk.changelog.md
+++ b/docs/changelogs/War3Net.IO.Slk.changelog.md
@@ -1,0 +1,48 @@
+# War3Net.IO.Slk Changelog
+
+All notable changes to the `War3Net.IO.Slk` package, newest version first.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v6.0.2] - 2026-03-01
+
+## [v6.0.1] - 2026-02-01
+
+## [v6.0.0] - 2026-01-25
+
+## [v5.8.1] - 2025-09-12
+
+## [v5.8.0] - 2025-09-06
+
+## v5.6.1 - 2023-01-07
+
+## v5.6.0 - 2022-12-20
+
+## v5.5.6 - 2022-11-30
+
+## v5.5.5 - 2022-11-13
+
+## v5.5.3 - 2022-10-29
+
+## v5.5.2 - 2022-10-25
+
+## v5.5.0 - 2022-08-20
+
+## v5.4.0 - 2022-02-13
+
+## v0.1.3 - 2021-11-24
+
+## v0.1.2 - 2021-10-31
+
+## v0.1.1 - 2020-10-27
+
+## v0.1.0 - 2020-09-14
+
+[Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
+[v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1
+[v6.0.1]: https://github.com/Drake53/War3Net/releases/tag/v2026.2.1
+[v6.0.0]: https://github.com/Drake53/War3Net/releases/tag/v2026.1.25
+[v5.8.1]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.12
+[v5.8.0]: https://github.com/Drake53/War3Net/releases/tag/v2025.9.6

--- a/docs/changelogs/War3Net.IO.Slk.changelog.md
+++ b/docs/changelogs/War3Net.IO.Slk.changelog.md
@@ -6,39 +6,131 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added .NET 10.0 target framework; the package now targets both .NET 6.0 and .NET 10.0.
+
 ## [v6.0.2] - 2026-03-01
+
+### Breaking Changes
+
+- Updated target framework from .NET 5.0 to .NET 6.0.
+
+### Changed
+
+- Updated `War3Net.Common` from v6.0.1 to v6.0.2.
 
 ## [v6.0.1] - 2026-02-01
 
+_No functional changes; package readme and metadata updated for nuget.org presentation._
+
 ## [v6.0.0] - 2026-01-25
+
+_No functional changes; version bumped to align with the rest of War3Net's v6.0.0 release._
 
 ## [v5.8.1] - 2025-09-12
 
+### Changed
+
+- Table dimensions on the `B` record are now parsed with invariant culture.
+
+### Fixed
+
+- The `X` field on `C` records is now optional; when omitted, the cell's column falls back to the previously parsed column, so .slk files using this shorthand no longer fail to parse.
+- A `C` record with a missing `X`, `Y`, or `K` field now throws a descriptive `InvalidDataException`/`NotSupportedException` instead of a `NullReferenceException`.
+
 ## [v5.8.0] - 2025-09-06
+
+### Fixed
+
+- Fixed `ArgumentOutOfRangeException` when a cell value consists of a single `"` character.
 
 ## v5.6.1 - 2023-01-07
 
+### Changed
+
+- Updated `War3Net.Common` from v5.6.0 to v5.6.1.
+
 ## v5.6.0 - 2022-12-20
+
+### Changed
+
+- Updated `War3Net.Common` from v5.5.5 to v5.6.0.
 
 ## v5.5.6 - 2022-11-30
 
+### Fixed
+
+- `SylkParser.SetCellContent` now parses cell coordinates and numeric values with `CultureInfo.InvariantCulture`, so files are no longer parsed incorrectly (or rejected) under cultures that use `,` as decimal separator.
+
 ## v5.5.5 - 2022-11-13
+
+### Changed
+
+- Updated `War3Net.Common` from v5.5.3 to v5.5.5.
 
 ## v5.5.3 - 2022-10-29
 
+### Changed
+
+- Updated `War3Net.Common` from v5.5.2 to v5.5.3.
+
 ## v5.5.2 - 2022-10-25
+
+### Changed
+
+- `SylkSerializer` now writes using `UTF8EncodingProvider.StrictUTF8` instead of constructing its own `UTF8Encoding`, adding a dependency on `War3Net.Common` (v5.5.2).
 
 ## v5.5.0 - 2022-08-20
 
+_No functional changes; version bumped to align with the rest of War3Net's v5.5.0 release._
+
 ## v5.4.0 - 2022-02-13
+
+_No functional changes; version bumped to align with the rest of War3Net's v5.4.0 release._
 
 ## v0.1.3 - 2021-11-24
 
+### Changed
+
+- The `NotSupportedException` thrown for unparsable values now includes the offending value in its message.
+
+### Fixed
+
+- `SylkParser` now accepts the `#REF!` error value and parses it as `0` (like `#VALUE!`), fixing a `NotSupportedException` when parsing files such as `unitweapons.slk` (fixes #21).
+
 ## v0.1.2 - 2021-10-31
+
+### Breaking Changes
+
+- Updated target framework from .NET Core 3.1 to .NET 5.0.
+
+### Added
+
+- Added `SylkTable.Combine(SylkTable, int, int)` overload, for joining two tables on 0-indexed column indices instead of column names.
+
+### Changed
+
+- Documented `Rows`, `Columns`, and the cell indexer as being 0-indexed.
+
+### Fixed
+
+- Fixed `SylkTable.Shrink` clipping off one row and one column too many, which dropped the last value of a table (fixes #16).
+- Fixed `SylkTable.Combine` producing incorrect results: it now sizes the resulting table from `Width`/`Height` instead of `Columns`/`Rows`, maps the other table's rows onto the joined rows correctly, and writes `newColumn` to the resulting table instead of mutating the source table.
+- `SylkTable.Combine` now throws `ArgumentNullException` when `other` is `null`.
+- Setting a cell to `null` now recalculates `Rows` and `Columns` instead of leaving them stale.
 
 ## v0.1.1 - 2020-10-27
 
+### Breaking Changes
+
+- Updated target framework from .NET Standard 2.1 to .NET Core 3.1.
+
 ## v0.1.0 - 2020-09-14
+
+### Added
+
+- Initial release, with `SylkParser`, `SylkTable`, and `SylkSerializer` for reading, manipulating, and writing SLK (SYLK) data files.
 
 [Unreleased]: https://github.com/Drake53/War3Net/compare/v6.0.3...HEAD
 [v6.0.2]: https://github.com/Drake53/War3Net/releases/tag/v2026.3.1


### PR DESCRIPTION
- Restructured existing changelogs to "Keep a Changelog" format.
- Added github release links to version headers, and pending commits links for unreleased changes.
- Added changelog files for packages which did not have one yet.
- Filled in missing version entries for existing changelogs.

Data sourced from nuget.org and git history. AI output not human-reviewed because years-old changelogs are not important enough to spend too much time on.